### PR TITLE
Notes on dependencies order in requitements.yaml

### DIFF
--- a/packs/D/preview/requirements.yaml
+++ b/packs/D/preview/requirements.yaml
@@ -1,4 +1,4 @@
-
+# !! File must end with empty line !!
 dependencies:
 - alias: expose
   name: exposecontroller
@@ -8,6 +8,9 @@ dependencies:
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io
   version: 2.3.56
+
+  # !! "alias: preview" must be last entry in dependencies array !!
+  # !! Place custom dependencies above !!
 - alias: preview
   name: REPLACE_ME_APP_NAME
   repository: file://../REPLACE_ME_APP_NAME

--- a/packs/appserver/preview/requirements.yaml
+++ b/packs/appserver/preview/requirements.yaml
@@ -1,4 +1,4 @@
-
+# !! File must end with empty line !!
 dependencies:
 - alias: expose
   name: exposecontroller
@@ -8,6 +8,9 @@ dependencies:
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io
   version: 2.3.56
+
+  # !! "alias: preview" must be last entry in dependencies array !!
+  # !! Place custom dependencies above !!
 - alias: preview
   name: REPLACE_ME_APP_NAME
   repository: file://../REPLACE_ME_APP_NAME

--- a/packs/dropwizard/preview/requirements.yaml
+++ b/packs/dropwizard/preview/requirements.yaml
@@ -1,4 +1,4 @@
-
+# !! File must end with empty line !!
 dependencies:
 - alias: expose
   name: exposecontroller
@@ -8,6 +8,9 @@ dependencies:
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io
   version: 2.3.56
+
+  # !! "alias: preview" must be last entry in dependencies array !!
+  # !! Place custom dependencies above !!
 - alias: preview
   name: REPLACE_ME_APP_NAME
   repository: file://../REPLACE_ME_APP_NAME

--- a/packs/go/preview/requirements.yaml
+++ b/packs/go/preview/requirements.yaml
@@ -1,4 +1,4 @@
-
+# !! File must end with empty line !!
 dependencies:
 - alias: expose
   name: exposecontroller
@@ -8,6 +8,9 @@ dependencies:
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io
   version: 2.3.56
+
+  # !! "alias: preview" must be last entry in dependencies array !!
+  # !! Place custom dependencies above !!
 - alias: preview
   name: REPLACE_ME_APP_NAME
   repository: file://../REPLACE_ME_APP_NAME

--- a/packs/gradle/preview/requirements.yaml
+++ b/packs/gradle/preview/requirements.yaml
@@ -1,4 +1,4 @@
-
+# !! File must end with empty line !!
 dependencies:
 - alias: expose
   name: exposecontroller
@@ -8,6 +8,9 @@ dependencies:
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io
   version: 2.3.56
+
+  # !! "alias: preview" must be last entry in dependencies array !!
+  # !! Place custom dependencies above !!
 - alias: preview
   name: REPLACE_ME_APP_NAME
   repository: file://../REPLACE_ME_APP_NAME

--- a/packs/javascript/preview/requirements.yaml
+++ b/packs/javascript/preview/requirements.yaml
@@ -1,4 +1,4 @@
-
+# !! File must end with empty line !!
 dependencies:
 - alias: expose
   name: exposecontroller
@@ -8,6 +8,9 @@ dependencies:
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io
   version: 2.3.56
+
+  # !! "alias: preview" must be last entry in dependencies array !!
+  # !! Place custom dependencies above !!
 - alias: preview
   name: REPLACE_ME_APP_NAME
   repository: file://../REPLACE_ME_APP_NAME

--- a/packs/liberty/preview/requirements.yaml
+++ b/packs/liberty/preview/requirements.yaml
@@ -1,4 +1,4 @@
-
+# !! File must end with empty line !!
 dependencies:
 - alias: expose
   name: exposecontroller
@@ -8,6 +8,9 @@ dependencies:
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io
   version: 2.3.56
+
+  # !! "alias: preview" must be last entry in dependencies array !!
+  # !! Place custom dependencies above !!
 - alias: preview
   name: REPLACE_ME_APP_NAME
   repository: file://../REPLACE_ME_APP_NAME

--- a/packs/maven/preview/requirements.yaml
+++ b/packs/maven/preview/requirements.yaml
@@ -1,4 +1,4 @@
-
+# !! File must end with empty line !!
 dependencies:
 - alias: expose
   name: exposecontroller
@@ -8,6 +8,9 @@ dependencies:
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io
   version: 2.3.56
+
+  # !! "alias: preview" must be last entry in dependencies array !!
+  # !! Place custom dependencies above !!
 - alias: preview
   name: REPLACE_ME_APP_NAME
   repository: file://../REPLACE_ME_APP_NAME

--- a/packs/python/preview/requirements.yaml
+++ b/packs/python/preview/requirements.yaml
@@ -1,4 +1,4 @@
-
+# !! File must end with empty line !!
 dependencies:
 - alias: expose
   name: exposecontroller
@@ -8,6 +8,9 @@ dependencies:
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io
   version: 2.3.56
+
+  # !! "alias: preview" must be last entry in dependencies array !!
+  # !! Place custom dependencies above !!
 - alias: preview
   name: REPLACE_ME_APP_NAME
   repository: file://../REPLACE_ME_APP_NAME

--- a/packs/ruby/preview/requirements.yaml
+++ b/packs/ruby/preview/requirements.yaml
@@ -1,4 +1,4 @@
-
+# !! File must end with empty line !!
 dependencies:
 - alias: expose
   name: exposecontroller
@@ -8,6 +8,9 @@ dependencies:
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io
   version: 2.3.56
+
+  # !! "alias: preview" must be last entry in dependencies array !!
+  # !! Place custom dependencies above !!
 - alias: preview
   name: REPLACE_ME_APP_NAME
   repository: file://../REPLACE_ME_APP_NAME

--- a/packs/rust/preview/requirements.yaml
+++ b/packs/rust/preview/requirements.yaml
@@ -1,4 +1,4 @@
-
+# !! File must end with empty line !!
 dependencies:
 - alias: expose
   name: exposecontroller
@@ -8,6 +8,9 @@ dependencies:
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io
   version: 2.3.56
+
+  # !! "alias: preview" must be last entry in dependencies array !!
+  # !! Place custom dependencies above !!
 - alias: preview
   name: REPLACE_ME_APP_NAME
   repository: file://../REPLACE_ME_APP_NAME

--- a/packs/scala/preview/requirements.yaml
+++ b/packs/scala/preview/requirements.yaml
@@ -1,4 +1,4 @@
-
+# !! File must end with empty line !!
 dependencies:
 - alias: expose
   name: exposecontroller
@@ -8,6 +8,9 @@ dependencies:
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io
   version: 2.3.56
+
+  # !! "alias: preview" must be last entry in dependencies array !!
+  # !! Place custom dependencies above !!
 - alias: preview
   name: REPLACE_ME_APP_NAME
   repository: file://../REPLACE_ME_APP_NAME


### PR DESCRIPTION
If "alias: preview" is not last entry in dependencies array following error occurs:

"Can't get a valid version for repositories postgresql".

It is due to how charts/preview/Makefile appends `$(PREVIEW_VERSION)` into requirements.yaml:

    ...
    echo "  version: $(PREVIEW_VERSION)" >> requirements.yaml
    jx step helm build

Also due to this `requirements.yaml` must end with an empty line.