### PR TITLE
Fix javascript pack

### DIFF
--- a/packs/typescript/skaffold.yaml
+++ b/packs/typescript/skaffold.yaml
@@ -5,8 +5,8 @@ build:
     envTemplate:
       template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
   artifacts:
-  - imageName: changeme
-    workspace: .
+  - image: changeme
+    context: .
     docker: {}
   local: {}
 deploy:


### PR DESCRIPTION
Before this patch, pipeline fails with following output:

```bash
+ skaffold build -f skaffold.yaml

time="2019-01-23T16:37:17Z" level=fatal msg="creating runner: parsing skaffold config: unable to parse config: yaml: unmarshal errors:\n  line 8: field imageName not found in type latest.Artifact\n  line 9: field workspace not found in type latest.Artifact"
```


See [here](https://github.com/GoogleContainerTools/skaffold/blob/master/examples/annotated-skaffold.yaml) for latest skaffold file spec.