### PR TITLE
Debian:8 for newer glibc

### DIFF
--- a/packs/rust/Dockerfile
+++ b/packs/rust/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM debian:8
 EXPOSE 8080
 CMD ["/REPLACE_ME_APP_NAME"]
 COPY ./ /


### PR DESCRIPTION
It is not possible to run rust-http under centos:7 docker image with Rocket 0.4.0 since it requires glibc 2.18 or higher, centos:7 provides glibc2.17 and when the container starts (after build finishes):
```shell
/my-rust-http-test: /lib64/libc.so.6: version `GLIBC_2.18' not found (required by /my-rust-http-test)
```
By using Debian:8, containers using Rocket 0.4.0 rust-http quickstart can be started.