### PR TITLE
Fixed Java11 container name

### DIFF
--- a/packs/maven-java11/pipeline.yaml
+++ b/packs/maven-java11/pipeline.yaml
@@ -2,4 +2,4 @@ extends:
   file: ../maven/pipeline.yaml
 agent:
   label: jenkins-maven-java11
-  container: maven
+  container: maven-java11


### PR DESCRIPTION
Fixed pipeline definition to match container name from platform - https://github.com/jenkins-x/jenkins-x-platform/blob/master/values.yaml#L909 .