### PR TITLE
feat: (Draft) add yaml Draft build pack support for Helm quickstarts

### DIFF
--- a/packs/yaml/pipeline.yaml
+++ b/packs/yaml/pipeline.yaml
@@ -1,0 +1,39 @@
+extends:
+  import: classic
+  file: pipeline.yaml
+agent:
+  label: jenkins-go
+  container: go
+pipelines:
+  pullRequest:
+    build:
+      steps:
+        - dir: charts/REPLACE_ME_APP_NAME
+          steps:
+            - sh: jx step helm build  
+
+  release:
+    setVersion:
+      steps:
+      - sh: echo \$(jx-release-version) > VERSION
+        comment: so we can retrieve the version in later steps
+    build:
+      steps:
+        - dir: charts/REPLACE_ME_APP_NAME
+          steps:
+            - sh: jx step helm build --verbose
+              comment: Let's build chart 
+            - sh: jx step tag --version \$(cat ../../VERSION) 
+              comment: Let's create tag in Git
+    promote:
+      steps:
+      - dir: charts/REPLACE_ME_APP_NAME
+        steps:
+        - sh: jx step changelog --version v\$(cat ../../VERSION)
+        - comment: Let's release the helm chart
+          sh: jx step helm release
+        - comment: Let's promote through all 'Auto' promotion Environments
+          sh: jx promote -b --all-auto --timeout 1h --version \$(cat ../../VERSION)
+
+
+

--- a/packs/yaml/pipeline.yaml
+++ b/packs/yaml/pipeline.yaml
@@ -2,8 +2,8 @@ extends:
   import: classic
   file: pipeline.yaml
 agent:
-  label: jenkins-go
-  container: go
+  label: jenkins-maven
+  container: maven
 pipelines:
   pullRequest:
     build:


### PR DESCRIPTION
This PR adds Yaml Draft build pack to enable  `Jx create quickstart` and `jx import` for Helm chart projects

Fixes jenkins-x/jx#2391

Helm Quickstart repository: https://github.com/igdianov/activiti-cloud-application-quickstart

Sample project Created from Helm Quckstart: https://github.com/igdianov/sample-activiti-cloud-app

```sh
jx create quickstartlocation --owner igdianov

jx create quickstart --owner igdianov -f quickstart
```
