### PR TITLE
modified python build pack to be able to build correctly

### DIFF
--- a/packs/python/Dockerfile
+++ b/packs/python/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:onbuild
+COPY requirements.txt .
 ENV PORT 8080
 EXPOSE 8080
 ENTRYPOINT ["python"]


### PR DESCRIPTION
Original solution by @ekiczek as documented here: https://kubernetes.slack.com/archives/C9MBGQJRH/p1543942194131600

This fix allowed me to successfully use python-http quickstart.