### PR TITLE
fix: don't tag in jx step next-version step

### DIFF
--- a/packs/docker-helm/pipeline.yaml
+++ b/packs/docker-helm/pipeline.yaml
@@ -20,7 +20,7 @@ pipelines:
   release:
     setVersion:
       steps:
-        - sh: jx step next-version --use-git-tag-only --tag=false
+        - sh: jx step next-version --use-git-tag-only
           name: tag-with-new-version
     build:
       steps:

--- a/packs/docker-helm/pipeline.yaml
+++ b/packs/docker-helm/pipeline.yaml
@@ -20,7 +20,7 @@ pipelines:
   release:
     setVersion:
       steps:
-        - sh: jx step next-version --use-git-tag-only --tag
+        - sh: jx step next-version --use-git-tag-only --tag=false
           name: tag-with-new-version
     build:
       steps:

--- a/packs/docker/pipeline.yaml
+++ b/packs/docker/pipeline.yaml
@@ -16,7 +16,7 @@ pipelines:
   release:
     setVersion:
       steps:
-      - sh: jx step next-version --use-git-tag-only --tag
+      - sh: jx step next-version --use-git-tag-only --tag=false
         name: tag-with-new-version
     build:
       steps:

--- a/packs/docker/pipeline.yaml
+++ b/packs/docker/pipeline.yaml
@@ -16,7 +16,7 @@ pipelines:
   release:
     setVersion:
       steps:
-      - sh: jx step next-version --use-git-tag-only --tag=false
+      - sh: jx step next-version --use-git-tag-only
         name: tag-with-new-version
     build:
       steps:

--- a/packs/helm/pipeline.yaml
+++ b/packs/helm/pipeline.yaml
@@ -16,7 +16,7 @@ pipelines:
   release:
     setVersion:
       steps:
-        - sh: jx step next-version --use-git-tag-only --tag
+        - sh: jx step next-version --use-git-tag-only --tag=false
           name: tag-with-new-version
     build:
       steps:

--- a/packs/helm/pipeline.yaml
+++ b/packs/helm/pipeline.yaml
@@ -16,7 +16,7 @@ pipelines:
   release:
     setVersion:
       steps:
-        - sh: jx step next-version --use-git-tag-only --tag=false
+        - sh: jx step next-version --use-git-tag-only
           name: tag-with-new-version
     build:
       steps:


### PR DESCRIPTION
This PR fixes problem that causes pipeline error when pushing the same tag twice while tagging Helm chart with `jx step tag` command . 

The following commits are responsible for the regression: https://github.com/jenkins-x-buildpacks/jenkins-x-kubernetes/commit/c10023063cee82e902e4576f0b9d7acac34a8fe6 and https://github.com/jenkins-x-buildpacks/jenkins-x-kubernetes/commit/6626557f9610f4357cd60bfd2749b8a1dd5e474f

