### PR TITLE
add build pack for micronaut gradle/java

### DIFF
--- a/packs/micronaut-gradle/.dockerignore
+++ b/packs/micronaut-gradle/.dockerignore
@@ -1,0 +1,5 @@
+draft.toml
+charts/
+NOTICE
+LICENSE
+README.md

--- a/packs/micronaut-gradle/.helmignore
+++ b/packs/micronaut-gradle/.helmignore
@@ -1,0 +1,27 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+*.png
+
+# known compile time folders
+target/
+node_modules/
+vendor/

--- a/packs/micronaut-gradle/Dockerfile
+++ b/packs/micronaut-gradle/Dockerfile
@@ -1,0 +1,4 @@
+FROM adoptopenjdk/openjdk11-openj9:jdk-11.0.1.13-alpine-slim
+COPY build/libs/app.jar ./app.jar
+EXPOSE 8080
+CMD java  -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dcom.sun.management.jmxremote -noverify ${JAVA_OPTS} -jar app.jar

--- a/packs/micronaut-gradle/charts/.helmignore
+++ b/packs/micronaut-gradle/charts/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/packs/micronaut-gradle/charts/Chart.yaml
+++ b/packs/micronaut-gradle/charts/Chart.yaml
@@ -1,0 +1,5 @@
+name: micronaut-gradle
+description: A Helm chart for Kubernetes
+apiVersion: v1
+version: 0.1.0-SNAPSHOT
+icon: https://raw.githubusercontent.com/jenkins-x/jenkins-x-platform/master/images/java.png

--- a/packs/micronaut-gradle/charts/Makefile
+++ b/packs/micronaut-gradle/charts/Makefile
@@ -1,0 +1,48 @@
+CHART_REPO := http://jenkins-x-chartmuseum:8080
+CURRENT=$(pwd)
+NAME := REPLACE_ME_APP_NAME
+OS := $(shell uname)
+RELEASE_VERSION := $(shell cat ../../VERSION)
+
+build: clean
+	rm -rf requirements.lock
+	helm dependency build
+	helm lint
+
+install: clean build
+	helm install . --name ${NAME}
+
+upgrade: clean build
+	helm upgrade ${NAME} .
+
+delete:
+	helm delete --purge ${NAME}
+
+clean:
+	rm -rf charts
+	rm -rf ${NAME}*.tgz
+
+release: clean
+	helm dependency build
+	helm lint
+	helm init --client-only
+	helm package .
+	curl --fail -u $(CHARTMUSEUM_CREDS_USR):$(CHARTMUSEUM_CREDS_PSW) --data-binary "@$(NAME)-$(shell sed -n 's/^version: //p' Chart.yaml).tgz" $(CHART_REPO)/api/charts
+	rm -rf ${NAME}*.tgz%
+
+tag:
+ifeq ($(OS),Darwin)
+	sed -i "" -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
+	sed -i "" -e "s/tag:.*/tag: $(RELEASE_VERSION)/" values.yaml
+else ifeq ($(OS),Linux)
+	sed -i -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
+	sed -i -e "s|repository:.*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_ORG\/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s/tag:.*/tag: $(RELEASE_VERSION)/" values.yaml
+else
+	echo "platfrom $(OS) not supported to release from"
+	exit -1
+endif
+	git add --all
+	git commit -m "release $(RELEASE_VERSION)" --allow-empty # if first release then no verion update is performed
+	git tag -fa v$(RELEASE_VERSION) -m "Release version $(RELEASE_VERSION)"
+	git push origin v$(RELEASE_VERSION)

--- a/packs/micronaut-gradle/charts/README.md
+++ b/packs/micronaut-gradle/charts/README.md
@@ -1,0 +1,1 @@
+# Java application

--- a/packs/micronaut-gradle/charts/templates/NOTES.txt
+++ b/packs/micronaut-gradle/charts/templates/NOTES.txt
@@ -1,0 +1,4 @@
+
+Get the application URL by running these commands:
+
+kubectl get ingress {{ template "fullname" . }}

--- a/packs/micronaut-gradle/charts/templates/_helpers.tpl
+++ b/packs/micronaut-gradle/charts/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/packs/micronaut-gradle/charts/templates/deployment.yaml
+++ b/packs/micronaut-gradle/charts/templates/deployment.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.knativeDeploy }}
+{{- else }}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    draft: {{ default "draft-app" .Values.draft }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        draft: {{ default "draft-app" .Values.draft }}
+        app: {{ template "fullname" . }}
+{{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+{{- range $pkey, $pval := .Values.env }}
+        - name: {{ $pkey }}
+          value: {{ $pval }}
+{{- end }}
+        ports:
+        - containerPort: {{ .Values.service.internalPort }}
+        livenessProbe:
+          httpGet:
+            path: {{ .Values.probePath }}
+            port: {{ .Values.service.internalPort }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+        readinessProbe:
+          httpGet:
+            path: {{ .Values.probePath }}
+            port: {{ .Values.service.internalPort }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+        resources:
+{{ toYaml .Values.resources | indent 12 }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+{{- end }}

--- a/packs/micronaut-gradle/charts/templates/ksvc.yaml
+++ b/packs/micronaut-gradle/charts/templates/ksvc.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.knativeDeploy }}
+apiVersion: serving.knative.dev/v1alpha1
+kind: Service
+metadata:
+{{- if .Values.service.name }}
+  name: {{ .Values.service.name }}
+{{- else }}
+  name: {{ template "fullname" . }}
+{{- end }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  runLatest:
+    configuration:
+      revisionTemplate:
+        spec:
+          container:
+            image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+            imagePullPolicy: {{ .Values.image.pullPolicy }}
+            env:
+{{- range $pkey, $pval := .Values.env }}
+            - name: {{ $pkey }}
+              value: {{ $pval }}
+{{- end }}
+            livenessProbe:
+              httpGet:
+                path: {{ .Values.probePath }}
+              initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+              periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+              successThreshold: {{ .Values.livenessProbe.successThreshold }}
+              timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            readinessProbe:
+              httpGet:
+                path: {{ .Values.probePath }}
+              periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+              successThreshold: {{ .Values.readinessProbe.successThreshold }}
+              timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+            resources:
+{{ toYaml .Values.resources | indent 12 }}
+{{- end }}

--- a/packs/micronaut-gradle/charts/templates/service.yaml
+++ b/packs/micronaut-gradle/charts/templates/service.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.knativeDeploy }}
+{{- else }}
+apiVersion: v1
+kind: Service
+metadata:
+{{- if .Values.service.name }}
+  name: {{ .Values.service.name }}
+{{- else }}
+  name: {{ template "fullname" . }}
+{{- end }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: {{ .Values.service.externalPort }}
+    targetPort: {{ .Values.service.internalPort }}
+    protocol: TCP
+    name: http
+  selector:
+    app: {{ template "fullname" . }}
+{{- end }}

--- a/packs/micronaut-gradle/charts/values.yaml
+++ b/packs/micronaut-gradle/charts/values.yaml
@@ -1,0 +1,41 @@
+# Default values for Micronaut Gradle projects.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 1
+image:
+  repository: draft
+  tag: dev
+  pullPolicy: IfNotPresent
+
+# define environment variables here as a map of key: value
+env:
+
+# enable this flag to use knative serve to deploy the app
+knativeDeploy: false
+
+service:
+  name: REPLACE_ME_APP_NAME
+  type: ClusterIP
+  externalPort: 80
+  internalPort: 8080
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: "kubernetes.io/ingress.class: nginx"
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 400m
+    memory: 512Mi
+probePath: /health
+livenessProbe:
+  initialDelaySeconds: 60
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 1
+readinessProbe:
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 1
+terminationGracePeriodSeconds: 10

--- a/packs/micronaut-gradle/pipeline.yaml
+++ b/packs/micronaut-gradle/pipeline.yaml
@@ -1,0 +1,45 @@
+extends:
+  import: classic
+  file: gradle/pipeline.yaml
+pipelines:
+  pullRequest:
+    build:
+      steps:
+      - sh: mv build/libs/*-all.jar build/libs/app.jar
+        name: pre-container-build
+      - sh: export VERSION=$PREVIEW_VERSION && skaffold build -f skaffold.yaml
+        name: container-build
+    postBuild:
+      steps:
+      - sh: jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION
+        name: post-build
+    promote:
+      steps:
+      - dir: ./charts/preview
+        steps:
+        - sh: make preview
+          name: make-preview
+        - sh: jx preview --app $APP_NAME --dir ../..
+          name: jx-preview
+
+  release:
+    build:
+      steps:
+      - sh: mv build/libs/*-all.jar build/libs/app.jar
+        name: pre-container-build
+      - sh: export VERSION=`cat VERSION` && skaffold build -f skaffold.yaml
+        name: container-build
+      - sh: jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION)
+        name: post-build
+    promote:
+      steps:
+      - dir: ./charts/REPLACE_ME_APP_NAME
+        steps:
+        - sh: jx step changelog --version v\$(cat ../../VERSION)
+          name: changelog
+        - comment: release the helm chart
+          sh: jx step helm release
+          name: helm-release
+        - comment: promote through all 'Auto' promotion Environments
+          sh: jx promote -b --all-auto --timeout 1h --version \$(cat ../../VERSION)
+          name: jx-promote

--- a/packs/micronaut-gradle/preview/Chart.yaml
+++ b/packs/micronaut-gradle/preview/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: preview
+icon: https://raw.githubusercontent.com/jenkins-x/jenkins-x-platform/master/images/java.png
+version: 0.1.0-SNAPSHOT

--- a/packs/micronaut-gradle/preview/Makefile
+++ b/packs/micronaut-gradle/preview/Makefile
@@ -1,0 +1,18 @@
+OS := $(shell uname)
+
+preview: 
+ifeq ($(OS),Darwin)
+	sed -i "" -e "s/version:.*/version: $(PREVIEW_VERSION)/" Chart.yaml
+	sed -i "" -e "s/version:.*/version: $(PREVIEW_VERSION)/" ../*/Chart.yaml
+	sed -i "" -e "s/tag:.*/tag: $(PREVIEW_VERSION)/" values.yaml
+else ifeq ($(OS),Linux)
+	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" Chart.yaml
+	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" ../*/Chart.yaml
+	sed -i -e "s|repository:.*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_ORG\/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s/tag:.*/tag: $(PREVIEW_VERSION)/" values.yaml
+else
+	echo "platfrom $(OS) not supported to release from"
+	exit -1
+endif
+	echo "  version: $(PREVIEW_VERSION)" >> requirements.yaml
+	jx step helm build

--- a/packs/micronaut-gradle/preview/requirements.yaml
+++ b/packs/micronaut-gradle/preview/requirements.yaml
@@ -1,0 +1,16 @@
+# !! File must end with empty line !!
+dependencies:
+- alias: expose
+  name: exposecontroller
+  repository: http://chartmuseum.jenkins-x.io
+  version: 2.3.92
+- alias: cleanup
+  name: exposecontroller
+  repository: http://chartmuseum.jenkins-x.io
+  version: 2.3.92
+
+  # !! "alias: preview" must be last entry in dependencies array !!
+  # !! Place custom dependencies above !!
+- alias: preview
+  name: REPLACE_ME_APP_NAME
+  repository: file://../REPLACE_ME_APP_NAME

--- a/packs/micronaut-gradle/preview/values.yaml
+++ b/packs/micronaut-gradle/preview/values.yaml
@@ -1,0 +1,22 @@
+
+expose:
+  Annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: hook-succeeded
+  config:
+    exposer: Ingress
+    http: true
+    tlsacme: false
+
+cleanup:
+  Args:
+    - --cleanup
+  Annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: hook-succeeded
+
+preview:
+  image:
+    repository:
+    tag:
+    pullPolicy: IfNotPresent

--- a/packs/micronaut-gradle/skaffold.yaml
+++ b/packs/micronaut-gradle/skaffold.yaml
@@ -1,0 +1,30 @@
+apiVersion: skaffold/v1beta2
+kind: Config
+build:
+  artifacts:
+  - image: changeme
+    context: .
+    docker: {}
+  tagPolicy:
+    envTemplate:
+      template: '{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}'
+  local: {}
+deploy:
+  kubectl: {}
+profiles:
+- name: dev
+  build:
+    artifacts:
+    - docker: {}
+    tagPolicy:
+      envTemplate:
+        template: '{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}'
+    local: {}
+  deploy:
+    helm:
+      releases:
+      - name: REPLACE_ME_APP_NAME
+        chartPath: charts/REPLACE_ME_APP_NAME
+        setValueTemplates:
+          image.repository: '{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME'
+          image.tag: '{{.DIGEST_HEX}}'

--- a/packs/micronaut-gradle/watch.sh
+++ b/packs/micronaut-gradle/watch.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# watch the java files and continously deploy the service
+gradle build
+skaffold run -p dev
+reflex -r "\.java$" -- bash -c 'gradle build && skaffold run -p dev'


### PR DESCRIPTION
Micronaut is gaining popularity, and the default is Java + Gradle.
However, it works slightly different from the default Gradle build pack, which is suited to Spring Boot.

Change of Health Check endpoint and a different Dockerfile.
The Dockerfile is the one generated by the Micronaut CLI.