### PR TITLE
fix: Save space on nexus by skipping superfluous deploy

### DIFF
--- a/packs/maven/pipeline.yaml
+++ b/packs/maven/pipeline.yaml
@@ -24,7 +24,10 @@ pipelines:
 
   release:
     build:
+      replace: true
       steps:
+      - sh: mvn clean package
+        name: mvn-install
       - sh: skaffold version
         name: skaffold-version
       - sh: export VERSION=`cat VERSION` && skaffold build -f skaffold.yaml


### PR DESCRIPTION
For an application the jar is only needed in the image.

Fixes jenkins-x/jx#3984