### PR TITLE
Buildpack for UI applications

### DIFF
--- a/packs/javascript-ui-nginx/.dockerignore
+++ b/packs/javascript-ui-nginx/.dockerignore
@@ -1,0 +1,5 @@
+draft.toml
+charts/
+NOTICE
+LICENSE
+README.md

--- a/packs/javascript-ui-nginx/.helmignore
+++ b/packs/javascript-ui-nginx/.helmignore
@@ -1,0 +1,27 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+*.png
+
+# known compile time folders
+target/
+node_modules/
+vendor/

--- a/packs/javascript-ui-nginx/Dockerfile
+++ b/packs/javascript-ui-nginx/Dockerfile
@@ -1,4 +1,4 @@
 FROM nginx:stable-alpine
-COPY /dist /user/share/nginx/html
+COPY /dist /usr/share/nginx/html
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/packs/javascript-ui-nginx/Dockerfile
+++ b/packs/javascript-ui-nginx/Dockerfile
@@ -1,0 +1,4 @@
+FROM nginx:stable-alpine
+COPY /dist /user/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/packs/javascript-ui-nginx/charts/.helmignore
+++ b/packs/javascript-ui-nginx/charts/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/packs/javascript-ui-nginx/charts/Chart.yaml
+++ b/packs/javascript-ui-nginx/charts/Chart.yaml
@@ -1,0 +1,5 @@
+name: javascript-ui-nginx
+description: A Helm chart for Kubernetes
+apiVersion: v1
+version: 0.1.0-SNAPSHOT
+icon: https://raw.githubusercontent.com/jenkins-x/jenkins-x-platform/d273e09/images/nodejs.png

--- a/packs/javascript-ui-nginx/charts/Makefile
+++ b/packs/javascript-ui-nginx/charts/Makefile
@@ -1,0 +1,48 @@
+CHART_REPO := http://jenkins-x-chartmuseum:8080
+CURRENT=$(pwd)
+NAME := REPLACE_ME_APP_NAME
+OS := $(shell uname)
+RELEASE_VERSION := $(shell cat ../../VERSION)
+
+build: clean
+	rm -rf requirements.lock
+	helm dependency build
+	helm lint
+
+install: clean build
+	helm install . --name ${NAME}
+
+upgrade: clean build
+	helm upgrade ${NAME} .
+
+delete:
+	helm delete --purge ${NAME}
+
+clean:
+	rm -rf charts
+	rm -rf ${NAME}*.tgz
+
+release: clean
+	helm dependency build
+	helm lint
+	helm init --client-only
+	helm package .
+	curl --fail -u $(CHARTMUSEUM_CREDS_USR):$(CHARTMUSEUM_CREDS_PSW) --data-binary "@$(NAME)-$(shell sed -n 's/^version: //p' Chart.yaml).tgz" $(CHART_REPO)/api/charts
+	rm -rf ${NAME}*.tgz%
+
+tag:
+ifeq ($(OS),Darwin)
+	sed -i "" -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
+	sed -i "" -e "s/tag:.*/tag: $(RELEASE_VERSION)/" values.yaml
+else ifeq ($(OS),Linux)
+	sed -i -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
+	sed -i -e "s|repository:.*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_DOCKER_REGISTRY_ORG\/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s/tag:.*/tag: $(RELEASE_VERSION)/" values.yaml
+else
+	echo "platfrom $(OS) not supported to release from"
+	exit -1
+endif
+	git add --all
+	git commit -m "release $(RELEASE_VERSION)" --allow-empty # if first release then no verion update is performed
+	git tag -fa v$(RELEASE_VERSION) -m "Release version $(RELEASE_VERSION)"
+	git push origin v$(RELEASE_VERSION)

--- a/packs/javascript-ui-nginx/charts/README.md
+++ b/packs/javascript-ui-nginx/charts/README.md
@@ -1,0 +1,1 @@
+# Javascript UI application with Nginx

--- a/packs/javascript-ui-nginx/charts/templates/NOTES.txt
+++ b/packs/javascript-ui-nginx/charts/templates/NOTES.txt
@@ -1,0 +1,4 @@
+
+Get the application URL by running these commands:
+
+kubectl get ingress {{ template "fullname" . }}

--- a/packs/javascript-ui-nginx/charts/templates/_helpers.tpl
+++ b/packs/javascript-ui-nginx/charts/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/packs/javascript-ui-nginx/charts/templates/deployment.yaml
+++ b/packs/javascript-ui-nginx/charts/templates/deployment.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.knativeDeploy }}
+{{- else }}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    draft: {{ default "draft-app" .Values.draft }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        draft: {{ default "draft-app" .Values.draft }}
+        app: {{ template "fullname" . }}
+{{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+{{- range $pkey, $pval := .Values.env }}
+        - name: {{ $pkey }}
+          value: {{ $pval }}
+{{- end }}
+        ports:
+        - containerPort: {{ .Values.service.internalPort }}
+        livenessProbe:
+          httpGet:
+            path: {{ .Values.probePath }}
+            port: {{ .Values.service.internalPort }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+        readinessProbe:
+          httpGet:
+            path: {{ .Values.probePath }}
+            port: {{ .Values.service.internalPort }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+        resources:
+{{ toYaml .Values.resources | indent 12 }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+{{- end }}

--- a/packs/javascript-ui-nginx/charts/templates/ksvc.yaml
+++ b/packs/javascript-ui-nginx/charts/templates/ksvc.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.knativeDeploy }}
+apiVersion: serving.knative.dev/v1alpha1
+kind: Service
+metadata:
+{{- if .Values.service.name }}
+  name: {{ .Values.service.name }}
+{{- else }}
+  name: {{ template "fullname" . }}
+{{- end }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  runLatest:
+    configuration:
+      revisionTemplate:
+        spec:
+          container:
+            image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+            imagePullPolicy: {{ .Values.image.pullPolicy }}
+            env:
+{{- range $pkey, $pval := .Values.env }}
+            - name: {{ $pkey }}
+              value: {{ $pval }}
+{{- end }}
+            livenessProbe:
+              httpGet:
+                path: {{ .Values.probePath }}
+              initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+              periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+              successThreshold: {{ .Values.livenessProbe.successThreshold }}
+              timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            readinessProbe:
+              httpGet:
+                path: {{ .Values.probePath }}
+              periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+              successThreshold: {{ .Values.readinessProbe.successThreshold }}
+              timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            resources:
+{{ toYaml .Values.resources | indent 14 }}
+{{- end }}

--- a/packs/javascript-ui-nginx/charts/templates/service.yaml
+++ b/packs/javascript-ui-nginx/charts/templates/service.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.knativeDeploy }}
+{{- else }}
+apiVersion: v1
+kind: Service
+metadata:
+{{- if .Values.service.name }}
+  name: {{ .Values.service.name }}
+{{- else }}
+  name: {{ template "fullname" . }}
+{{- end }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: {{ .Values.service.externalPort }}
+    targetPort: {{ .Values.service.internalPort }}
+    protocol: TCP
+    name: http
+  selector:
+    app: {{ template "fullname" . }}
+{{- end }}

--- a/packs/javascript-ui-nginx/charts/values.yaml
+++ b/packs/javascript-ui-nginx/charts/values.yaml
@@ -1,0 +1,40 @@
+# Default values for node projects.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 1
+image:
+  repository: draft
+  tag: dev
+  pullPolicy: IfNotPresent
+
+# define environment variables here as a map of key: value
+env:
+
+# enable this flag to use knative serve to deploy the app
+knativeDeploy: false
+
+service:
+  name: REPLACE_ME_APP_NAME
+  type: ClusterIP
+  externalPort: 80
+  internalPort: 80
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: "kubernetes.io/ingress.class: nginx"
+resources:
+  limits:
+    cpu: 400m
+    memory: 256Mi
+  requests:
+    cpu: 200m
+    memory: 128Mi
+probePath: /
+livenessProbe:
+  initialDelaySeconds: 60
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 1
+readinessProbe:
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 1

--- a/packs/javascript-ui-nginx/pipeline.yaml
+++ b/packs/javascript-ui-nginx/pipeline.yaml
@@ -1,0 +1,45 @@
+extends:
+  import: classic
+  file: javascript/pipeline.yaml
+pipelines:
+  pullRequest:
+    build:
+      steps:
+      - sh: npm run build
+        name: ui-build
+      - sh: export VERSION=$PREVIEW_VERSION && skaffold build -f skaffold.yaml
+        name: container-build
+    postBuild:
+      steps:
+      - sh: jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION
+        name: post-build
+    promote:
+      steps:
+      - dir: ./charts/preview
+        steps:
+        - sh: make preview
+          name: make-preview
+        - sh: jx preview --app $APP_NAME --dir ../..
+          name: jx-preview
+
+  release:
+    build:
+      steps:
+      - sh: npm run build
+        name: ui-build
+      - sh: export VERSION=`cat VERSION` && skaffold build -f skaffold.yaml
+        name: container-build
+      - sh: jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION)
+        name: post-build
+    promote:
+      steps:
+      - dir: ./charts/REPLACE_ME_APP_NAME
+        steps:
+        - sh: jx step changelog --batch-mode --version v\$(cat ../../VERSION)
+          name: changelog
+        - comment: release the helm chart
+          sh: jx step helm release
+          name: helm-release
+        - comment: promote through all 'Auto' promotion Environments
+          sh: jx promote -b --all-auto --timeout 1h --version \$(cat ../../VERSION)
+          name: jx-promote

--- a/packs/javascript-ui-nginx/preview/Chart.yaml
+++ b/packs/javascript-ui-nginx/preview/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: preview
+icon: https://raw.githubusercontent.com/jenkins-x/jenkins-x-platform/d273e09/images/nodejs.png
+version: 0.1.0-SNAPSHOT

--- a/packs/javascript-ui-nginx/preview/Makefile
+++ b/packs/javascript-ui-nginx/preview/Makefile
@@ -1,0 +1,18 @@
+OS := $(shell uname)
+
+preview: 
+ifeq ($(OS),Darwin)
+	sed -i "" -e "s/version:.*/version: $(PREVIEW_VERSION)/" Chart.yaml
+	sed -i "" -e "s/version:.*/version: $(PREVIEW_VERSION)/" ../*/Chart.yaml
+	sed -i "" -e "s/tag:.*/tag: $(PREVIEW_VERSION)/" values.yaml
+else ifeq ($(OS),Linux)
+	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" Chart.yaml
+	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" ../*/Chart.yaml
+	sed -i -e "s|repository:.*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_DOCKER_REGISTRY_ORG\/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s/tag:.*/tag: $(PREVIEW_VERSION)/" values.yaml
+else
+	echo "platfrom $(OS) not supported to release from"
+	exit -1
+endif
+	echo "  version: $(PREVIEW_VERSION)" >> requirements.yaml
+	jx step helm build

--- a/packs/javascript-ui-nginx/preview/requirements.yaml
+++ b/packs/javascript-ui-nginx/preview/requirements.yaml
@@ -1,0 +1,16 @@
+# !! File must end with empty line !!
+dependencies:
+- alias: expose
+  name: exposecontroller
+  repository: http://chartmuseum.jenkins-x.io
+  version: 2.3.92
+- alias: cleanup
+  name: exposecontroller
+  repository: http://chartmuseum.jenkins-x.io
+  version: 2.3.92
+
+  # !! "alias: preview" must be last entry in dependencies array !!
+  # !! Place custom dependencies above !!
+- alias: preview
+  name: REPLACE_ME_APP_NAME
+  repository: file://../REPLACE_ME_APP_NAME

--- a/packs/javascript-ui-nginx/preview/values.yaml
+++ b/packs/javascript-ui-nginx/preview/values.yaml
@@ -1,0 +1,22 @@
+
+expose:
+  Annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: hook-succeeded
+  config:
+    exposer: Ingress
+    http: true
+    tlsacme: false
+
+cleanup:
+  Args:
+    - --cleanup
+  Annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: hook-succeeded
+
+preview:
+  image:
+    repository:
+    tag:
+    pullPolicy: IfNotPresent

--- a/packs/javascript-ui-nginx/skaffold.yaml
+++ b/packs/javascript-ui-nginx/skaffold.yaml
@@ -1,0 +1,28 @@
+apiVersion: skaffold/v1beta2
+kind: Config
+build:
+  artifacts:
+  - image: REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME
+    context: .
+    docker: {}
+  tagPolicy:
+    envTemplate:
+      template: '{{.DOCKER_REGISTRY}}/{{.IMAGE_NAME}}:{{.VERSION}}'
+  local: {}
+deploy:
+  kubectl: {}
+profiles:
+- name: dev
+  build:
+    tagPolicy:
+      envTemplate:
+        template: '{{.DOCKER_REGISTRY}}/{{.IMAGE_NAME}}:{{.DIGEST_HEX}}'
+    local: {}
+  deploy:
+    helm:
+      releases:
+      - name: REPLACE_ME_APP_NAME
+        chartPath: charts/REPLACE_ME_APP_NAME
+        setValueTemplates:
+          image.repository: '{{.DOCKER_REGISTRY}}/{{.IMAGE_NAME}}'
+          image.tag: '{{.DIGEST_HEX}}'


### PR DESCRIPTION
At the moment there is no buildpack for pure UI application which usually gets built and statically served by a running container.
The implementation in this PR makes it easy to import an UI application with related building step before the docker image creation (through extend is only possible with the replace option and include all the needed commands).
Usually these are the desired steps:
- npm install
- npm run test
- npm run build *
- ...build docker image with nginx...

Instance:
- Nginx serves the generated static files within the container