### PR TITLE
fix: Quote the environment variable values in deployment.yaml to avoid 'cannot convert int64 to string' error

### DIFF
--- a/packs/C++/charts/templates/deployment.yaml
+++ b/packs/C++/charts/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         env:
 {{- range $pkey, $pval := .Values.env }}
         - name: {{ $pkey }}
-          value: {{ $pval }}
+          value: {{ quote $pval }}
 {{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}

--- a/packs/C++/charts/templates/ksvc.yaml
+++ b/packs/C++/charts/templates/ksvc.yaml
@@ -20,7 +20,7 @@ spec:
             env:
 {{- range $pkey, $pval := .Values.env }}
             - name: {{ $pkey }}
-              value: {{ $pval }}
+              value: {{ quote $pval }}
 {{- end }}
             livenessProbe:
               httpGet:

--- a/packs/D/charts/templates/deployment.yaml
+++ b/packs/D/charts/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         env:
 {{- range $pkey, $pval := .Values.env }}
         - name: {{ $pkey }}
-          value: {{ $pval }}
+          value: {{ quote $pval }}
 {{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}

--- a/packs/D/charts/templates/ksvc.yaml
+++ b/packs/D/charts/templates/ksvc.yaml
@@ -20,7 +20,7 @@ spec:
             env:
 {{- range $pkey, $pval := .Values.env }}
             - name: {{ $pkey }}
-              value: {{ $pval }}
+              value: {{ quote $pval }}
 {{- end }}
             livenessProbe:
               httpGet:

--- a/packs/appserver/charts/templates/deployment.yaml
+++ b/packs/appserver/charts/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         env:
 {{- range $pkey, $pval := .Values.env }}
         - name: {{ $pkey }}
-          value: {{ $pval }}
+          value: {{ quote $pval }}
 {{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}

--- a/packs/appserver/charts/templates/ksvc.yaml
+++ b/packs/appserver/charts/templates/ksvc.yaml
@@ -20,7 +20,7 @@ spec:
             env:
 {{- range $pkey, $pval := .Values.env }}
             - name: {{ $pkey }}
-              value: {{ $pval }}
+              value: {{ quote $pval }}
 {{- end }}
             livenessProbe:
               httpGet:

--- a/packs/csharp/charts/templates/deployment.yaml
+++ b/packs/csharp/charts/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         env:
 {{- range $pkey, $pval := .Values.env }}
         - name: {{ $pkey }}
-          value: {{ $pval }}
+          value: {{ quote $pval }}
 {{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}

--- a/packs/csharp/charts/templates/ksvc.yaml
+++ b/packs/csharp/charts/templates/ksvc.yaml
@@ -20,7 +20,7 @@ spec:
             env:
 {{- range $pkey, $pval := .Values.env }}
             - name: {{ $pkey }}
-              value: {{ $pval }}
+              value: {{ quote $pval }}
 {{- end }}
             livenessProbe:
               httpGet:

--- a/packs/cwp/charts/templates/deployment.yaml
+++ b/packs/cwp/charts/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         env:
 {{- range $pkey, $pval := .Values.env }}
         - name: {{ $pkey }}
-          value: {{ $pval }}
+          value: {{ quote $pval }}
 {{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}

--- a/packs/cwp/charts/templates/ksvc.yaml
+++ b/packs/cwp/charts/templates/ksvc.yaml
@@ -20,7 +20,7 @@ spec:
             env:
 {{- range $pkey, $pval := .Values.env }}
             - name: {{ $pkey }}
-              value: {{ $pval }}
+              value: {{ quote $pval }}
 {{- end }}
             livenessProbe:
               httpGet:

--- a/packs/dropwizard/charts/templates/deployment.yaml
+++ b/packs/dropwizard/charts/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         env:
 {{- range $pkey, $pval := .Values.env }}
         - name: {{ $pkey }}
-          value: {{ $pval }}
+          value: {{ quote $pval }}
 {{- end }}
         ports:
         - containerPort: {{ .Values.service.appPort }}

--- a/packs/dropwizard/charts/templates/ksvc.yaml
+++ b/packs/dropwizard/charts/templates/ksvc.yaml
@@ -20,7 +20,7 @@ spec:
             env:
 {{- range $pkey, $pval := .Values.env }}
             - name: {{ $pkey }}
-              value: {{ $pval }}
+              value: {{ quote $pval }}
 {{- end }}
             livenessProbe:
               httpGet:

--- a/packs/go-mongodb/charts/templates/deployment.yaml
+++ b/packs/go-mongodb/charts/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           value: {{ template "fullname" . }}-db
 {{- range $pkey, $pval := .Values.env }}
         - name: {{ $pkey }}
-          value: {{ $pval }}
+          value: {{ quote $pval }}
 {{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}

--- a/packs/go-mongodb/charts/templates/ksvc.yaml
+++ b/packs/go-mongodb/charts/templates/ksvc.yaml
@@ -20,7 +20,7 @@ spec:
             env:
 {{- range $pkey, $pval := .Values.env }}
             - name: {{ $pkey }}
-              value: {{ $pval }}
+              value: {{ quote $pval }}
 {{- end }}
             livenessProbe:
               httpGet:

--- a/packs/go/charts/templates/deployment.yaml
+++ b/packs/go/charts/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         env:
 {{- range $pkey, $pval := .Values.env }}
         - name: {{ $pkey }}
-          value: {{ $pval }}
+          value: {{ quote $pval }}
 {{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}

--- a/packs/go/charts/templates/ksvc.yaml
+++ b/packs/go/charts/templates/ksvc.yaml
@@ -20,7 +20,7 @@ spec:
             env:
 {{- range $pkey, $pval := .Values.env }}
             - name: {{ $pkey }}
-              value: {{ $pval }}
+              value: {{ quote $pval }}
 {{- end }}
             livenessProbe:
               httpGet:

--- a/packs/gradle/charts/templates/deployment.yaml
+++ b/packs/gradle/charts/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         env:
 {{- range $pkey, $pval := .Values.env }}
         - name: {{ $pkey }}
-          value: {{ $pval }}
+          value: {{ quote $pval }}
 {{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}

--- a/packs/gradle/charts/templates/ksvc.yaml
+++ b/packs/gradle/charts/templates/ksvc.yaml
@@ -20,7 +20,7 @@ spec:
             env:
 {{- range $pkey, $pval := .Values.env }}
             - name: {{ $pkey }}
-              value: {{ $pval }}
+              value: {{ quote $pval }}
 {{- end }}
             livenessProbe:
               httpGet:

--- a/packs/javascript/charts/templates/deployment.yaml
+++ b/packs/javascript/charts/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         env:
 {{- range $pkey, $pval := .Values.env }}
         - name: {{ $pkey }}
-          value: {{ $pval }}
+          value: {{ quote $pval }}
 {{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}

--- a/packs/javascript/charts/templates/ksvc.yaml
+++ b/packs/javascript/charts/templates/ksvc.yaml
@@ -20,7 +20,7 @@ spec:
             env:
 {{- range $pkey, $pval := .Values.env }}
             - name: {{ $pkey }}
-              value: {{ $pval }}
+              value: {{ quote $pval }}
 {{- end }}
             livenessProbe:
               httpGet:

--- a/packs/liberty/charts/templates/deployment.yaml
+++ b/packs/liberty/charts/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         env:
 {{- range $pkey, $pval := .Values.env }}
         - name: {{ $pkey }}
-          value: {{ $pval }}
+          value: {{ quote $pval }}
 {{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}

--- a/packs/liberty/charts/templates/ksvc.yaml
+++ b/packs/liberty/charts/templates/ksvc.yaml
@@ -20,7 +20,7 @@ spec:
             env:
 {{- range $pkey, $pval := .Values.env }}
             - name: {{ $pkey }}
-              value: {{ $pval }}
+              value: {{ quote $pval }}
 {{- end }}
             livenessProbe:
               httpGet:

--- a/packs/maven-java11/charts/templates/deployment.yaml
+++ b/packs/maven-java11/charts/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         env:
 {{- range $pkey, $pval := .Values.env }}
         - name: {{ $pkey }}
-          value: {{ $pval }}
+          value: {{ quote $pval }}
 {{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}

--- a/packs/maven-java11/charts/templates/ksvc.yaml
+++ b/packs/maven-java11/charts/templates/ksvc.yaml
@@ -20,7 +20,7 @@ spec:
             env:
 {{- range $pkey, $pval := .Values.env }}
             - name: {{ $pkey }}
-              value: {{ $pval }}
+              value: {{ quote $pval }}
 {{- end }}
             livenessProbe:
               httpGet:

--- a/packs/maven/charts/templates/deployment.yaml
+++ b/packs/maven/charts/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         env:
 {{- range $pkey, $pval := .Values.env }}
         - name: {{ $pkey }}
-          value: {{ $pval }}
+          value: {{ quote $pval }}
 {{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}

--- a/packs/maven/charts/templates/ksvc.yaml
+++ b/packs/maven/charts/templates/ksvc.yaml
@@ -20,7 +20,7 @@ spec:
             env:
 {{- range $pkey, $pval := .Values.env }}
             - name: {{ $pkey }}
-              value: {{ $pval }}
+              value: {{ quote $pval }}
 {{- end }}
             livenessProbe:
               httpGet:

--- a/packs/ml-python-gpu-service/charts/templates/deployment.yaml
+++ b/packs/ml-python-gpu-service/charts/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         env:
 {{- range $pkey, $pval := .Values.env }}
         - name: {{ $pkey }}
-          value: {{ $pval }}
+          value: {{ quote $pval }}
 {{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}

--- a/packs/ml-python-gpu-service/charts/templates/ksvc.yaml
+++ b/packs/ml-python-gpu-service/charts/templates/ksvc.yaml
@@ -16,7 +16,7 @@ spec:
             env:
 {{- range $pkey, $pval := .Values.env }}
             - name: {{ $pkey }}
-              value: {{ $pval }}
+              value: {{ quote $pval }}
 {{- end }}
             livenessProbe:
               httpGet:

--- a/packs/ml-python-gpu-training/charts/templates/deployment.yaml
+++ b/packs/ml-python-gpu-training/charts/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           value: {{ .Chart.Name | replace "-training" "-service"}}
 {{- range $pkey, $pval := .Values.env }}
         - name: {{ $pkey }}
-          value: {{ $pval }}
+          value: {{ quote $pval }}
 {{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}

--- a/packs/ml-python-gpu-training/charts/templates/ksvc.yaml
+++ b/packs/ml-python-gpu-training/charts/templates/ksvc.yaml
@@ -16,7 +16,7 @@ spec:
             env:
 {{- range $pkey, $pval := .Values.env }}
             - name: {{ $pkey }}
-              value: {{ $pval }}
+              value: {{ quote $pval }}
 {{- end }}
             livenessProbe:
               httpGet:

--- a/packs/ml-python-service/charts/templates/deployment.yaml
+++ b/packs/ml-python-service/charts/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         env:
 {{- range $pkey, $pval := .Values.env }}
         - name: {{ $pkey }}
-          value: {{ $pval }}
+          value: {{ quote $pval }}
 {{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}

--- a/packs/ml-python-service/charts/templates/ksvc.yaml
+++ b/packs/ml-python-service/charts/templates/ksvc.yaml
@@ -16,7 +16,7 @@ spec:
             env:
 {{- range $pkey, $pval := .Values.env }}
             - name: {{ $pkey }}
-              value: {{ $pval }}
+              value: {{ quote $pval }}
 {{- end }}
             livenessProbe:
               httpGet:

--- a/packs/ml-python-training/charts/templates/deployment.yaml
+++ b/packs/ml-python-training/charts/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           value: {{ .Chart.Name | replace "-training" "-service"}}
 {{- range $pkey, $pval := .Values.env }}
         - name: {{ $pkey }}
-          value: {{ $pval }}
+          value: {{ quote $pval }}
 {{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}

--- a/packs/ml-python-training/charts/templates/ksvc.yaml
+++ b/packs/ml-python-training/charts/templates/ksvc.yaml
@@ -16,7 +16,7 @@ spec:
             env:
 {{- range $pkey, $pval := .Values.env }}
             - name: {{ $pkey }}
-              value: {{ $pval }}
+              value: {{ quote $pval }}
 {{- end }}
             livenessProbe:
               httpGet:

--- a/packs/php/charts/templates/deployment.yaml
+++ b/packs/php/charts/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         env:
 {{- range $pkey, $pval := .Values.env }}
         - name: {{ $pkey }}
-          value: {{ $pval }}
+          value: {{ quote $pval }}
 {{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}

--- a/packs/php/charts/templates/ksvc.yaml
+++ b/packs/php/charts/templates/ksvc.yaml
@@ -20,7 +20,7 @@ spec:
             env:
 {{- range $pkey, $pval := .Values.env }}
             - name: {{ $pkey }}
-              value: {{ $pval }}
+              value: {{ quote $pval }}
 {{- end }}
             livenessProbe:
               httpGet:

--- a/packs/python/charts/templates/deployment.yaml
+++ b/packs/python/charts/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         env:
 {{- range $pkey, $pval := .Values.env }}
         - name: {{ $pkey }}
-          value: {{ $pval }}
+          value: {{ quote $pval }}
 {{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}

--- a/packs/python/charts/templates/ksvc.yaml
+++ b/packs/python/charts/templates/ksvc.yaml
@@ -20,7 +20,7 @@ spec:
             env:
 {{- range $pkey, $pval := .Values.env }}
             - name: {{ $pkey }}
-              value: {{ $pval }}
+              value: {{ quote $pval }}
 {{- end }}
             livenessProbe:
               httpGet:

--- a/packs/ruby/charts/templates/deployment.yaml
+++ b/packs/ruby/charts/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         env:
 {{- range $pkey, $pval := .Values.env }}
         - name: {{ $pkey }}
-          value: {{ $pval }}
+          value: {{ quote $pval }}
 {{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}

--- a/packs/ruby/charts/templates/ksvc.yaml
+++ b/packs/ruby/charts/templates/ksvc.yaml
@@ -20,7 +20,7 @@ spec:
             env:
 {{- range $pkey, $pval := .Values.env }}
             - name: {{ $pkey }}
-              value: {{ $pval }}
+              value: {{ quote $pval }}
 {{- end }}
             livenessProbe:
               httpGet:

--- a/packs/rust/charts/templates/deployment.yaml
+++ b/packs/rust/charts/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         env:
 {{- range $pkey, $pval := .Values.env }}
         - name: {{ $pkey }}
-          value: {{ $pval }}
+          value: {{ quote $pval }}
 {{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}

--- a/packs/rust/charts/templates/ksvc.yaml
+++ b/packs/rust/charts/templates/ksvc.yaml
@@ -20,7 +20,7 @@ spec:
             env:
 {{- range $pkey, $pval := .Values.env }}
             - name: {{ $pkey }}
-              value: {{ $pval }}
+              value: {{ quote $pval }}
 {{- end }}
             livenessProbe:
               httpGet:

--- a/packs/scala/charts/templates/deployment.yaml
+++ b/packs/scala/charts/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         env:
 {{- range $pkey, $pval := .Values.env }}
         - name: {{ $pkey }}
-          value: {{ $pval }}
+          value: {{ quote $pval }}
 {{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}

--- a/packs/scala/charts/templates/ksvc.yaml
+++ b/packs/scala/charts/templates/ksvc.yaml
@@ -20,7 +20,7 @@ spec:
             env:
 {{- range $pkey, $pval := .Values.env }}
             - name: {{ $pkey }}
-              value: {{ $pval }}
+              value: {{ quote $pval }}
 {{- end }}
             livenessProbe:
               httpGet:

--- a/packs/swift/chart/templates/deployment.yaml
+++ b/packs/swift/chart/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         env:
 {{- range $pkey, $pval := .Values.env }}
         - name: {{ $pkey }}
-          value: {{ $pval }}
+          value: {{ quote $pval }}
 {{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}

--- a/packs/swift/chart/templates/ksvc.yaml
+++ b/packs/swift/chart/templates/ksvc.yaml
@@ -20,7 +20,7 @@ spec:
             env:
 {{- range $pkey, $pval := .Values.env }}
             - name: {{ $pkey }}
-              value: {{ $pval }}
+              value: {{ quote $pval }}
 {{- end }}
             livenessProbe:
               httpGet:

--- a/packs/typescript/charts/templates/deployment.yaml
+++ b/packs/typescript/charts/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         env:
 {{- range $pkey, $pval := .Values.env }}
         - name: {{ $pkey }}
-          value: {{ $pval }}
+          value: {{ quote $pval }}
 {{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}

--- a/packs/typescript/charts/templates/ksvc.yaml
+++ b/packs/typescript/charts/templates/ksvc.yaml
@@ -20,7 +20,7 @@ spec:
             env:
 {{- range $pkey, $pval := .Values.env }}
             - name: {{ $pkey }}
-              value: {{ $pval }}
+              value: {{ quote $pval }}
 {{- end }}
             livenessProbe:
               httpGet:


### PR DESCRIPTION
…d the 'cannot convert int64 to string' error when the value is an integer (even quoted) in values.yaml.