### PR TITLE
Adding envFrom in deployment.yaml

### DIFF
--- a/packs/C++/charts/templates/deployment.yaml
+++ b/packs/C++/charts/templates/deployment.yaml
@@ -28,6 +28,8 @@ spec:
         - name: {{ $pkey }}
           value: {{ quote $pval }}
 {{- end }}
+        envFrom:
+{{ toYaml .Values.envFrom | indent 10 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/packs/D/charts/templates/deployment.yaml
+++ b/packs/D/charts/templates/deployment.yaml
@@ -28,6 +28,8 @@ spec:
         - name: {{ $pkey }}
           value: {{ quote $pval }}
 {{- end }}
+        envFrom:
+{{ toYaml .Values.envFrom | indent 10 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/packs/appserver/charts/templates/deployment.yaml
+++ b/packs/appserver/charts/templates/deployment.yaml
@@ -28,6 +28,8 @@ spec:
         - name: {{ $pkey }}
           value: {{ quote $pval }}
 {{- end }}
+        envFrom:
+{{ toYaml .Values.envFrom | indent 10 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/packs/csharp/charts/templates/deployment.yaml
+++ b/packs/csharp/charts/templates/deployment.yaml
@@ -28,6 +28,8 @@ spec:
         - name: {{ $pkey }}
           value: {{ quote $pval }}
 {{- end }}
+        envFrom:
+{{ toYaml .Values.envFrom | indent 10 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         resources:

--- a/packs/cwp/charts/templates/deployment.yaml
+++ b/packs/cwp/charts/templates/deployment.yaml
@@ -28,6 +28,8 @@ spec:
         - name: {{ $pkey }}
           value: {{ quote $pval }}
 {{- end }}
+        envFrom:
+{{ toYaml .Values.envFrom | indent 10 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/packs/dropwizard/charts/templates/deployment.yaml
+++ b/packs/dropwizard/charts/templates/deployment.yaml
@@ -28,6 +28,8 @@ spec:
         - name: {{ $pkey }}
           value: {{ quote $pval }}
 {{- end }}
+        envFrom:
+{{ toYaml .Values.envFrom | indent 10 }}
         ports:
         - containerPort: {{ .Values.service.appPort }}
         - containerPort: {{ .Values.service.adminPort }}

--- a/packs/go-mongodb/charts/templates/deployment.yaml
+++ b/packs/go-mongodb/charts/templates/deployment.yaml
@@ -30,6 +30,8 @@ spec:
         - name: {{ $pkey }}
           value: {{ quote $pval }}
 {{- end }}
+        envFrom:
+{{ toYaml .Values.envFrom | indent 10 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/packs/go/charts/templates/deployment.yaml
+++ b/packs/go/charts/templates/deployment.yaml
@@ -28,6 +28,8 @@ spec:
         - name: {{ $pkey }}
           value: {{ quote $pval }}
 {{- end }}
+        envFrom:
+{{ toYaml .Values.envFrom | indent 10 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/packs/gradle/charts/templates/deployment.yaml
+++ b/packs/gradle/charts/templates/deployment.yaml
@@ -28,6 +28,8 @@ spec:
         - name: {{ $pkey }}
           value: {{ quote $pval }}
 {{- end }}
+        envFrom:
+{{ toYaml .Values.envFrom | indent 10 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/packs/javascript/charts/templates/deployment.yaml
+++ b/packs/javascript/charts/templates/deployment.yaml
@@ -28,6 +28,8 @@ spec:
         - name: {{ $pkey }}
           value: {{ quote $pval }}
 {{- end }}
+        envFrom:
+{{ toYaml .Values.envFrom | indent 10 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/packs/liberty/charts/templates/deployment.yaml
+++ b/packs/liberty/charts/templates/deployment.yaml
@@ -28,6 +28,8 @@ spec:
         - name: {{ $pkey }}
           value: {{ quote $pval }}
 {{- end }}
+        envFrom:
+{{ toYaml .Values.envFrom | indent 10 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/packs/maven-java11/charts/templates/deployment.yaml
+++ b/packs/maven-java11/charts/templates/deployment.yaml
@@ -28,6 +28,8 @@ spec:
         - name: {{ $pkey }}
           value: {{ quote $pval }}
 {{- end }}
+        envFrom:
+{{ toYaml .Values.envFrom | indent 10 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/packs/maven/charts/templates/deployment.yaml
+++ b/packs/maven/charts/templates/deployment.yaml
@@ -28,6 +28,8 @@ spec:
         - name: {{ $pkey }}
           value: {{ quote $pval }}
 {{- end }}
+        envFrom:
+{{ toYaml .Values.envFrom | indent 10 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/packs/ml-python-gpu-service/charts/templates/deployment.yaml
+++ b/packs/ml-python-gpu-service/charts/templates/deployment.yaml
@@ -28,6 +28,8 @@ spec:
         - name: {{ $pkey }}
           value: {{ quote $pval }}
 {{- end }}
+        envFrom:
+{{ toYaml .Values.envFrom | indent 10 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         resources:

--- a/packs/ml-python-gpu-training/charts/templates/deployment.yaml
+++ b/packs/ml-python-gpu-training/charts/templates/deployment.yaml
@@ -30,6 +30,8 @@ spec:
         - name: {{ $pkey }}
           value: {{ quote $pval }}
 {{- end }}
+        envFrom:
+{{ toYaml .Values.envFrom | indent 10 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         resources:

--- a/packs/ml-python-service/charts/templates/deployment.yaml
+++ b/packs/ml-python-service/charts/templates/deployment.yaml
@@ -28,6 +28,8 @@ spec:
         - name: {{ $pkey }}
           value: {{ quote $pval }}
 {{- end }}
+        envFrom:
+{{ toYaml .Values.envFrom | indent 10 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         resources:

--- a/packs/ml-python-training/charts/templates/deployment.yaml
+++ b/packs/ml-python-training/charts/templates/deployment.yaml
@@ -30,6 +30,8 @@ spec:
         - name: {{ $pkey }}
           value: {{ quote $pval }}
 {{- end }}
+        envFrom:
+{{ toYaml .Values.envFrom | indent 10 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         resources:

--- a/packs/php/charts/templates/deployment.yaml
+++ b/packs/php/charts/templates/deployment.yaml
@@ -28,6 +28,8 @@ spec:
         - name: {{ $pkey }}
           value: {{ quote $pval }}
 {{- end }}
+        envFrom:
+{{ toYaml .Values.envFrom | indent 10 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/packs/python/charts/templates/deployment.yaml
+++ b/packs/python/charts/templates/deployment.yaml
@@ -28,6 +28,8 @@ spec:
         - name: {{ $pkey }}
           value: {{ quote $pval }}
 {{- end }}
+        envFrom:
+{{ toYaml .Values.envFrom | indent 10 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         resources:

--- a/packs/ruby/charts/templates/deployment.yaml
+++ b/packs/ruby/charts/templates/deployment.yaml
@@ -28,6 +28,8 @@ spec:
         - name: {{ $pkey }}
           value: {{ quote $pval }}
 {{- end }}
+        envFrom:
+{{ toYaml .Values.envFrom | indent 10 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/packs/rust/charts/templates/deployment.yaml
+++ b/packs/rust/charts/templates/deployment.yaml
@@ -28,6 +28,8 @@ spec:
         - name: {{ $pkey }}
           value: {{ quote $pval }}
 {{- end }}
+        envFrom:
+{{ toYaml .Values.envFrom | indent 10 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/packs/scala/charts/templates/deployment.yaml
+++ b/packs/scala/charts/templates/deployment.yaml
@@ -28,6 +28,8 @@ spec:
         - name: {{ $pkey }}
           value: {{ quote $pval }}
 {{- end }}
+        envFrom:
+{{ toYaml .Values.envFrom | indent 10 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/packs/swift/chart/templates/deployment.yaml
+++ b/packs/swift/chart/templates/deployment.yaml
@@ -28,6 +28,8 @@ spec:
         - name: {{ $pkey }}
           value: {{ quote $pval }}
 {{- end }}
+        envFrom:
+{{ toYaml .Values.envFrom | indent 10 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         resources:

--- a/packs/typescript/charts/templates/deployment.yaml
+++ b/packs/typescript/charts/templates/deployment.yaml
@@ -28,6 +28,8 @@ spec:
         - name: {{ $pkey }}
           value: {{ quote $pval }}
 {{- end }}
+        envFrom:
+{{ toYaml .Values.envFrom | indent 10 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:


### PR DESCRIPTION
Adding envFrom in deployment.yaml, It's useful if we want to retrieve Environment variables from Config Maps.