### PR TITLE
fix: Don't use tagless images unless they're pod template names

### DIFF
--- a/packs/charts/pipeline.yaml
+++ b/packs/charts/pipeline.yaml
@@ -1,6 +1,6 @@
 agent:
   label: jenkins-jx-base
-  container: gcr.io/jenkinsxio/builder-go
+  container: go
 pipelines:
   pullRequest:
     build:

--- a/packs/environment/pipeline.yaml
+++ b/packs/environment/pipeline.yaml
@@ -3,7 +3,7 @@ extends:
   file: pipeline.yaml
 agent:
   label: jenkins-go
-  container: gcr.io/jenkinsxio/builder-go
+  container: go
 pipelines:
   release:
     build:


### PR DESCRIPTION
See https://github.com/jenkins-x/jx/issues/4615. Regardless of what we
do about that issue in the end, we shouldn't be using
`gcr.io/jenkinsxio/builder-go` as the image in the first place. `go`
(i.e., referring to the pod template name) will always pick up the
latest in the version stream, which is what we'd want anyway (and what
we do everywhere else here).

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>