### PR TITLE
fix: Catch situation where pipeline is run again against existing PR

### DIFF
--- a/packs/ml-python-gpu-training/pipeline.yaml
+++ b/packs/ml-python-gpu-training/pipeline.yaml
@@ -63,7 +63,7 @@ pipelines:
               cp ../*.onnx . &&
               cp -r ../metrics . &&
               git add *.onnx metrics &&
-              jx create pullrequest --push -b --title 'New model trained' --body 'feat: New model trained' &&
+              { jx create pullrequest --push -b --title 'New model trained' --body 'feat: New model trained' || echo 'Using previous PR'; } &&
               sha1sum *.onnx >&2
           name: export-model
 

--- a/packs/ml-python-training/pipeline.yaml
+++ b/packs/ml-python-training/pipeline.yaml
@@ -57,7 +57,7 @@ pipelines:
             git lfs track '*.onnx' &&
             cp ../*.onnx . &&
             git add *.onnx &&
-            jx create pullrequest --push -b --title 'New model trained' --body 'feat: New model trained' &&
+            { jx create pullrequest --push -b --title 'New model trained' --body 'feat: New model trained' || echo 'Using previous PR'; } &&
             sha1sum *.onnx >&2
         name: export-model
   post:


### PR DESCRIPTION
Signed-off-by: Terry Cox <terry@bootstrap.je>

Simple change in response to `jx create pullrequest` returning an error if a PR already exists for the project.