### PR TITLE
Fixed typo in Chart.yaml

### DIFF
--- a/packs/go/charts/Chart.yaml
+++ b/packs/go/charts/Chart.yaml
@@ -1,4 +1,4 @@
-name: javascript
+name: golang
 description: A Helm chart for Kubernetes
 apiVersion: v1
 version: 0.1.0-SNAPSHOT


### PR DESCRIPTION
The golang Helm Chart had `javascript` instead of `golang` set as name.