### PR TITLE
Istio with go

### DIFF
--- a/packs/go/charts/templates/istio.yaml
+++ b/packs/go/charts/templates/istio.yaml
@@ -1,0 +1,74 @@
+{{- if .Values.istio.enabled }}
+
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+{{- if .Values.service.name }}
+  name: {{ .Values.service.name }}
+{{- else }}
+  name: {{ template "fullname" . }}
+{{- end }}
+spec:
+  hosts:
+{{ toYaml .Values.istio.hosts | indent 2 }}
+  gateways:
+{{- if .Values.service.name }}
+  - {{ .Values.service.name }}
+{{- else }}
+  - {{ template "fullname" . }}
+{{- end }}
+  http:
+  - match:
+    route:
+    - destination:
+{{- if .Values.service.name }}
+        host: {{ .Values.service.name }}
+{{- else }}
+        host: {{ template "fullname" . }}
+{{- end }}
+        port:
+          number: {{ .Values.service.externalPort }}
+
+---
+
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+{{- if .Values.service.name }}
+  name: {{ .Values.service.name }}
+{{- else }}
+  name: {{ template "fullname" . }}
+{{- end }}
+spec:
+{{- if .Values.service.name }}
+  host: {{ .Values.service.name }}
+{{- else }}
+  host: {{ template "fullname" . }}
+{{- end }}
+  subsets:
+  - name: v1
+    labels:
+      app: {{ template "fullname" . }}
+
+---
+
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+{{- if .Values.service.name }}
+  name: {{ .Values.service.name }}
+{{- else }}
+  name: {{ template "fullname" . }}
+{{- end }}
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - port:
+      number: {{ .Values.service.externalPort }}
+      name: http
+      protocol: HTTP
+    hosts:
+{{ toYaml .Values.istio.hosts | indent 4 }}
+
+{{- end }}

--- a/packs/go/charts/values.yaml
+++ b/packs/go/charts/values.yaml
@@ -13,6 +13,11 @@ env:
 # enable this flag to use knative serve to deploy the app
 knativeDeploy: false
 
+# enable this flag to use Istio
+istio:
+  enabled: false
+  hosts: {}
+
 service:
   name: REPLACE_ME_APP_NAME
   type: ClusterIP


### PR DESCRIPTION
This PR adds Istio support to the `go` pack. It is a safe addition because all the changes are within a conditional that uses `istio.enabled` value that is by default set to `false`. I tested it quite a few times (manually) and I could not find any issue. If the PR is approved, I plan to create new ones soon. They would first add the same to other packs. After that, I'll add changes that will allow canary and blue-green deployments as well as other Istio-specific features.