### PR TITLE
Issue #74- update jenkins build home

### DIFF
--- a/packs/go-mongodb/pipeline.yaml
+++ b/packs/go-mongodb/pipeline.yaml
@@ -11,7 +11,7 @@ pipelines:
       - sh: jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION
     promote:
       steps:
-      - dir: /home/jenkins/go/src/REPLACE_ME_GIT_PROVIDER/REPLACE_ME_ORG/REPLACE_ME_APP_NAME/charts/preview
+      - dir: /home/jenkins/agent/go/src/REPLACE_ME_GIT_PROVIDER/REPLACE_ME_ORG/REPLACE_ME_APP_NAME/charts/preview
         steps:
         - sh: make preview
         - sh: jx preview --app $APP_NAME --dir ../..
@@ -23,7 +23,7 @@ pipelines:
       - sh: jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION)
     promote:
       steps:
-      - dir: /home/jenkins/go/src/REPLACE_ME_GIT_PROVIDER/REPLACE_ME_ORG/REPLACE_ME_APP_NAME/charts/REPLACE_ME_APP_NAME
+      - dir: /home/jenkins/agent/go/src/REPLACE_ME_GIT_PROVIDER/REPLACE_ME_ORG/REPLACE_ME_APP_NAME/charts/REPLACE_ME_APP_NAME
         steps:
         - sh: jx step changelog --version v\$(cat ../../VERSION)
         - comment: release the helm chart

--- a/packs/go/pipeline.yaml
+++ b/packs/go/pipeline.yaml
@@ -13,7 +13,7 @@ pipelines:
         name: post-build
     promote:
       steps:
-      - dir: /home/jenkins/go/src/REPLACE_ME_GIT_PROVIDER/REPLACE_ME_ORG/REPLACE_ME_APP_NAME/charts/preview
+      - dir: /home/jenkins/agent/go/src/REPLACE_ME_GIT_PROVIDER/REPLACE_ME_ORG/REPLACE_ME_APP_NAME/charts/preview
         steps:
         - sh: make preview
           name: make-preview
@@ -29,7 +29,7 @@ pipelines:
         name: post-build
     promote:
       steps:
-      - dir: /home/jenkins/go/src/REPLACE_ME_GIT_PROVIDER/REPLACE_ME_ORG/REPLACE_ME_APP_NAME/charts/REPLACE_ME_APP_NAME
+      - dir: /home/jenkins/agent/go/src/REPLACE_ME_GIT_PROVIDER/REPLACE_ME_ORG/REPLACE_ME_APP_NAME/charts/REPLACE_ME_APP_NAME
         steps:
         - sh: jx step changelog --version v\$(cat ../../VERSION)
           name: changelog


### PR DESCRIPTION
Issue #74 

When using Jenkinsfile, the /home/jenkins directory needs to be /home/jenkins/agent due to upstream change.

https://issues.jenkins-ci.org/browse/JENKINS-58705

https://github.com/jenkinsci/kubernetes-plugin/pull/559/files