### PR TITLE
change image to java 11

### DIFF
--- a/packs/maven-java11/pipeline.yaml
+++ b/packs/maven-java11/pipeline.yaml
@@ -2,4 +2,5 @@ extends:
   file: ../maven/pipeline.yaml
 agent:
   label: jenkins-maven-java11
+  image: maven-java11
   container: maven


### PR DESCRIPTION
The image used was still Java 8, meaning, you couldn't build Java 11 applications with this build pack.

As raised via this issue: https://github.com/jenkins-x/jx/issues/3742