### PR TITLE
Updated Deployment and Ingress API versions

### DIFF
--- a/packs/C++/charts/templates/deployment.yaml
+++ b/packs/C++/charts/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.knativeDeploy }}
 {{- else }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -8,6 +8,9 @@ metadata:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
 {{- if .Values.hpa.enabled }}
 {{- else }}
   replicas: {{ .Values.replicaCount }}

--- a/packs/D/charts/templates/deployment.yaml
+++ b/packs/D/charts/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.knativeDeploy }}
 {{- else }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -8,6 +8,9 @@ metadata:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
 {{- if .Values.hpa.enabled }}
 {{- else }}
   replicas: {{ .Values.replicaCount }}

--- a/packs/appserver/charts/templates/deployment.yaml
+++ b/packs/appserver/charts/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.knativeDeploy }}
 {{- else }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -8,6 +8,9 @@ metadata:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
 {{- if .Values.hpa.enabled }}
 {{- else }}
   replicas: {{ .Values.replicaCount }}

--- a/packs/csharp/charts/templates/deployment.yaml
+++ b/packs/csharp/charts/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.knativeDeploy }}
 {{- else }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -8,6 +8,9 @@ metadata:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
 {{- if .Values.hpa.enabled }}
 {{- else }}
   replicas: {{ .Values.replicaCount }}

--- a/packs/csharp/preview/templates/deployment.yaml
+++ b/packs/csharp/preview/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.knativeDeploy }}
 {{- else }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -8,6 +8,9 @@ metadata:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:

--- a/packs/cwp/charts/templates/deployment.yaml
+++ b/packs/cwp/charts/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.knativeDeploy }}
 {{- else }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -8,6 +8,9 @@ metadata:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
 {{- if .Values.hpa.enabled }}
 {{- else }}
   replicas: {{ .Values.replicaCount }}

--- a/packs/dropwizard/charts/templates/deployment.yaml
+++ b/packs/dropwizard/charts/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.knativeDeploy }}
 {{- else }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -8,6 +8,9 @@ metadata:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
 {{- if .Values.hpa.enabled }}
 {{- else }}
   replicas: {{ .Values.replicaCount }}

--- a/packs/go-mongodb/charts/templates/deployment.yaml
+++ b/packs/go-mongodb/charts/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.knativeDeploy }}
 {{- else }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -8,6 +8,9 @@ metadata:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
 {{- if .Values.hpa.enabled }}
 {{- else }}
   replicas: {{ .Values.replicaCount }}

--- a/packs/go/charts/templates/deployment.yaml
+++ b/packs/go/charts/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.knativeDeploy }}
 {{- else }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -8,6 +8,9 @@ metadata:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
 {{- if .Values.hpa.enabled }}
 {{- else }}
   replicas: {{ .Values.replicaCount }}

--- a/packs/gradle/charts/templates/deployment.yaml
+++ b/packs/gradle/charts/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.knativeDeploy }}
 {{- else }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -8,6 +8,9 @@ metadata:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
 {{- if .Values.hpa.enabled }}
 {{- else }}
   replicas: {{ .Values.replicaCount }}

--- a/packs/javascript-ui-nginx/charts/templates/deployment.yaml
+++ b/packs/javascript-ui-nginx/charts/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.knativeDeploy }}
 {{- else }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -8,6 +8,9 @@ metadata:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
 {{- if .Values.hpa.enabled }}
 {{- else }}
   replicas: {{ .Values.replicaCount }}

--- a/packs/javascript/charts/templates/deployment.yaml
+++ b/packs/javascript/charts/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.knativeDeploy }}
 {{- else }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -8,6 +8,9 @@ metadata:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
 {{- if .Values.hpa.enabled }}
 {{- else }}
   replicas: {{ .Values.replicaCount }}

--- a/packs/liberty/charts/templates/deployment.yaml
+++ b/packs/liberty/charts/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.knativeDeploy }}
 {{- else }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -8,6 +8,9 @@ metadata:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
 {{- if .Values.hpa.enabled }}
 {{- else }}
   replicas: {{ .Values.replicaCount }}

--- a/packs/maven-java11/charts/templates/deployment.yaml
+++ b/packs/maven-java11/charts/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.knativeDeploy }}
 {{- else }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -8,6 +8,9 @@ metadata:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
 {{- if .Values.hpa.enabled }}
 {{- else }}
   replicas: {{ .Values.replicaCount }}

--- a/packs/maven-node-ruby/charts/templates/deployment.yaml
+++ b/packs/maven-node-ruby/charts/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.knativeDeploy }}
 {{- else }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -8,6 +8,9 @@ metadata:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
 {{- if .Values.hpa.enabled }}
 {{- else }}
   replicas: {{ .Values.replicaCount }}

--- a/packs/maven-quarkus/charts/templates/deployment.yaml
+++ b/packs/maven-quarkus/charts/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.knativeDeploy }}
 {{- else }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -8,6 +8,9 @@ metadata:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
 {{- if .Values.hpa.enabled }}
 {{- else }}
   replicas: {{ .Values.replicaCount }}

--- a/packs/maven/charts/templates/deployment.yaml
+++ b/packs/maven/charts/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.knativeDeploy }}
 {{- else }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -8,6 +8,9 @@ metadata:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
 {{- if .Values.hpa.enabled }}
 {{- else }}
   replicas: {{ .Values.replicaCount }}

--- a/packs/ml-python-gpu-service/charts/templates/deployment.yaml
+++ b/packs/ml-python-gpu-service/charts/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.knativeDeploy }}
 {{- else }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -8,6 +8,9 @@ metadata:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:

--- a/packs/ml-python-gpu-service/charts/templates/ingress.yaml
+++ b/packs/ml-python-gpu-service/charts/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "fullname" . }}

--- a/packs/ml-python-gpu-training/charts/templates/deployment.yaml
+++ b/packs/ml-python-gpu-training/charts/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.knativeDeploy }}
 {{- else }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -8,6 +8,9 @@ metadata:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:

--- a/packs/ml-python-gpu-training/charts/templates/ingress.yaml
+++ b/packs/ml-python-gpu-training/charts/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "fullname" . }}

--- a/packs/ml-python-service/charts/templates/deployment.yaml
+++ b/packs/ml-python-service/charts/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.knativeDeploy }}
 {{- else }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -8,6 +8,9 @@ metadata:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:

--- a/packs/ml-python-service/charts/templates/ingress.yaml
+++ b/packs/ml-python-service/charts/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "fullname" . }}

--- a/packs/ml-python-training/charts/templates/deployment.yaml
+++ b/packs/ml-python-training/charts/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.knativeDeploy }}
 {{- else }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -8,6 +8,9 @@ metadata:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:

--- a/packs/ml-python-training/charts/templates/ingress.yaml
+++ b/packs/ml-python-training/charts/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "fullname" . }}

--- a/packs/php/charts/templates/deployment.yaml
+++ b/packs/php/charts/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.knativeDeploy }}
 {{- else }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -8,6 +8,9 @@ metadata:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
 {{- if .Values.hpa.enabled }}
 {{- else }}
   replicas: {{ .Values.replicaCount }}

--- a/packs/python/charts/templates/deployment.yaml
+++ b/packs/python/charts/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.knativeDeploy }}
 {{- else }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -8,6 +8,9 @@ metadata:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
 {{- if .Values.hpa.enabled }}
 {{- else }}
   replicas: {{ .Values.replicaCount }}

--- a/packs/python/charts/templates/ingress.yaml
+++ b/packs/python/charts/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "fullname" . }}

--- a/packs/ruby/charts/templates/deployment.yaml
+++ b/packs/ruby/charts/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.knativeDeploy }}
 {{- else }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -8,6 +8,9 @@ metadata:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
 {{- if .Values.hpa.enabled }}
 {{- else }}
   replicas: {{ .Values.replicaCount }}

--- a/packs/rust/charts/templates/deployment.yaml
+++ b/packs/rust/charts/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.knativeDeploy }}
 {{- else }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -8,6 +8,9 @@ metadata:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
 {{- if .Values.hpa.enabled }}
 {{- else }}
   replicas: {{ .Values.replicaCount }}

--- a/packs/scala/charts/templates/deployment.yaml
+++ b/packs/scala/charts/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.knativeDeploy }}
 {{- else }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -8,6 +8,9 @@ metadata:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
 {{- if .Values.hpa.enabled }}
 {{- else }}
   replicas: {{ .Values.replicaCount }}

--- a/packs/swift/chart/templates/deployment.yaml
+++ b/packs/swift/chart/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.knativeDeploy }}
 {{- else }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -8,6 +8,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     draft: {{ default "draft-app" .Values.draft }}
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
 {{- if .Values.hpa.enabled }}
 {{- else }}
   replicas: {{ .Values.replicaCount }}

--- a/packs/swift/chart/templates/ingress.yaml
+++ b/packs/swift/chart/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "fullname" . }}

--- a/packs/typescript/charts/templates/deployment.yaml
+++ b/packs/typescript/charts/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.knativeDeploy }}
 {{- else }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -8,6 +8,9 @@ metadata:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
 {{- if .Values.hpa.enabled }}
 {{- else }}
   replicas: {{ .Values.replicaCount }}


### PR DESCRIPTION
Ingress API version changed since Kubernetes 1.14. Deployment is v1 at least since Kubernetes version 1.10 (probably even earlier).

Now, I could not test all those packs and, as far as I know, there are no automated tests to validate them. What would be the best way to proceed?