### PR TITLE
Fix: csharp preview step fails

### DIFF
--- a/packs/csharp/pipeline.yaml
+++ b/packs/csharp/pipeline.yaml
@@ -1,9 +1,6 @@
 extends:
   import: classic
   file: pipeline.yaml
-agent:
-  label: jenkins-jx-base
-  container: jx-base
 pipelines:
   pullRequest:
     build:

--- a/packs/csharp/preview/Makefile
+++ b/packs/csharp/preview/Makefile
@@ -8,8 +8,7 @@ ifeq ($(OS),Darwin)
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" Chart.yaml
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" ../*/Chart.yaml
-	sed -i -e "s|repository:.*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_ORG\/REPLACE_ME_APP_NAME|" values.yaml
-	sed -i -e "s/tag:.*/tag: $(PREVIEW_VERSION)/" values.yaml
+	sed -i -e "s|repository:.*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_DOCKER_REGISTRY_ORG\/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag:.*/tag: $(PREVIEW_VERSION)/" values.yaml
 	pwd
 	ls


### PR DESCRIPTION
CSharp preview step fails due to:

- missing helm local repo (similar as here https://github.com/jenkins-x/jx/issues/3682), changes in pipeline.yaml;
- wrong docker image tag and docker repository, changes in Makefile.