### PR TITLE
Use toYaml for the environment variables to be able to use valueFrom

### DIFF
--- a/packs/C++/charts/templates/deployment.yaml
+++ b/packs/C++/charts/templates/deployment.yaml
@@ -24,10 +24,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
-{{- range $pkey, $pval := .Values.env }}
-        - name: {{ $pkey }}
-          value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 8 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/packs/C++/charts/templates/ksvc.yaml
+++ b/packs/C++/charts/templates/ksvc.yaml
@@ -18,10 +18,7 @@ spec:
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             env:
-{{- range $pkey, $pval := .Values.env }}
-            - name: {{ $pkey }}
-              value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 12 }}
             livenessProbe:
               httpGet:
                 path: {{ .Values.probePath }}

--- a/packs/D/charts/templates/deployment.yaml
+++ b/packs/D/charts/templates/deployment.yaml
@@ -24,10 +24,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
-{{- range $pkey, $pval := .Values.env }}
-        - name: {{ $pkey }}
-          value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 8 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/packs/D/charts/templates/ksvc.yaml
+++ b/packs/D/charts/templates/ksvc.yaml
@@ -18,10 +18,7 @@ spec:
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             env:
-{{- range $pkey, $pval := .Values.env }}
-            - name: {{ $pkey }}
-              value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 12 }}
             livenessProbe:
               httpGet:
                 path: {{ .Values.probePath }}

--- a/packs/appserver/charts/templates/deployment.yaml
+++ b/packs/appserver/charts/templates/deployment.yaml
@@ -24,10 +24,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
-{{- range $pkey, $pval := .Values.env }}
-        - name: {{ $pkey }}
-          value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 8 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/packs/appserver/charts/templates/ksvc.yaml
+++ b/packs/appserver/charts/templates/ksvc.yaml
@@ -18,10 +18,7 @@ spec:
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             env:
-{{- range $pkey, $pval := .Values.env }}
-            - name: {{ $pkey }}
-              value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 12 }}
             livenessProbe:
               httpGet:
                 path: {{ .Values.probePath }}

--- a/packs/csharp/charts/templates/deployment.yaml
+++ b/packs/csharp/charts/templates/deployment.yaml
@@ -24,10 +24,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
-{{- range $pkey, $pval := .Values.env }}
-        - name: {{ $pkey }}
-          value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 8 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         resources:

--- a/packs/csharp/charts/templates/ksvc.yaml
+++ b/packs/csharp/charts/templates/ksvc.yaml
@@ -18,10 +18,7 @@ spec:
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             env:
-{{- range $pkey, $pval := .Values.env }}
-            - name: {{ $pkey }}
-              value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 12 }}
             livenessProbe:
               httpGet:
                 path: {{ .Values.probePath }}

--- a/packs/cwp/charts/templates/deployment.yaml
+++ b/packs/cwp/charts/templates/deployment.yaml
@@ -24,10 +24,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
-{{- range $pkey, $pval := .Values.env }}
-        - name: {{ $pkey }}
-          value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 8 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/packs/cwp/charts/templates/ksvc.yaml
+++ b/packs/cwp/charts/templates/ksvc.yaml
@@ -18,10 +18,7 @@ spec:
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             env:
-{{- range $pkey, $pval := .Values.env }}
-            - name: {{ $pkey }}
-              value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 12 }}
             livenessProbe:
               httpGet:
                 path: {{ .Values.probePath }}

--- a/packs/dropwizard/charts/templates/deployment.yaml
+++ b/packs/dropwizard/charts/templates/deployment.yaml
@@ -24,10 +24,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
-{{- range $pkey, $pval := .Values.env }}
-        - name: {{ $pkey }}
-          value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 8 }}
         ports:
         - containerPort: {{ .Values.service.appPort }}
         - containerPort: {{ .Values.service.adminPort }}

--- a/packs/dropwizard/charts/templates/ksvc.yaml
+++ b/packs/dropwizard/charts/templates/ksvc.yaml
@@ -18,10 +18,7 @@ spec:
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             env:
-{{- range $pkey, $pval := .Values.env }}
-            - name: {{ $pkey }}
-              value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 12 }}
             livenessProbe:
               httpGet:
                 path: {{ .Values.probePath }}

--- a/packs/go-mongodb/charts/templates/deployment.yaml
+++ b/packs/go-mongodb/charts/templates/deployment.yaml
@@ -26,10 +26,7 @@ spec:
         env:
         - name: DB
           value: {{ template "fullname" . }}-db
-{{- range $pkey, $pval := .Values.env }}
-        - name: {{ $pkey }}
-          value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 8 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/packs/go-mongodb/charts/templates/ksvc.yaml
+++ b/packs/go-mongodb/charts/templates/ksvc.yaml
@@ -18,10 +18,7 @@ spec:
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             env:
-{{- range $pkey, $pval := .Values.env }}
-            - name: {{ $pkey }}
-              value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 12 }}
             livenessProbe:
               httpGet:
                 path: {{ .Values.probePath }}

--- a/packs/go/charts/templates/deployment.yaml
+++ b/packs/go/charts/templates/deployment.yaml
@@ -24,10 +24,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
-{{- range $pkey, $pval := .Values.env }}
-        - name: {{ $pkey }}
-          value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 8 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/packs/go/charts/templates/ksvc.yaml
+++ b/packs/go/charts/templates/ksvc.yaml
@@ -18,10 +18,7 @@ spec:
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             env:
-{{- range $pkey, $pval := .Values.env }}
-            - name: {{ $pkey }}
-              value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 12 }}
             livenessProbe:
               httpGet:
                 path: {{ .Values.probePath }}

--- a/packs/gradle/charts/templates/deployment.yaml
+++ b/packs/gradle/charts/templates/deployment.yaml
@@ -24,10 +24,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
-{{- range $pkey, $pval := .Values.env }}
-        - name: {{ $pkey }}
-          value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 8 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/packs/gradle/charts/templates/ksvc.yaml
+++ b/packs/gradle/charts/templates/ksvc.yaml
@@ -18,10 +18,7 @@ spec:
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             env:
-{{- range $pkey, $pval := .Values.env }}
-            - name: {{ $pkey }}
-              value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 12 }}
             livenessProbe:
               httpGet:
                 path: {{ .Values.probePath }}

--- a/packs/javascript/charts/templates/deployment.yaml
+++ b/packs/javascript/charts/templates/deployment.yaml
@@ -24,10 +24,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
-{{- range $pkey, $pval := .Values.env }}
-        - name: {{ $pkey }}
-          value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 8 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/packs/javascript/charts/templates/ksvc.yaml
+++ b/packs/javascript/charts/templates/ksvc.yaml
@@ -18,10 +18,7 @@ spec:
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             env:
-{{- range $pkey, $pval := .Values.env }}
-            - name: {{ $pkey }}
-              value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 12 }}
             livenessProbe:
               httpGet:
                 path: {{ .Values.probePath }}

--- a/packs/liberty/charts/templates/deployment.yaml
+++ b/packs/liberty/charts/templates/deployment.yaml
@@ -24,10 +24,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
-{{- range $pkey, $pval := .Values.env }}
-        - name: {{ $pkey }}
-          value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 8 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/packs/liberty/charts/templates/ksvc.yaml
+++ b/packs/liberty/charts/templates/ksvc.yaml
@@ -18,10 +18,7 @@ spec:
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             env:
-{{- range $pkey, $pval := .Values.env }}
-            - name: {{ $pkey }}
-              value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 12 }}
             livenessProbe:
               httpGet:
                 path: {{ .Values.probePath }}

--- a/packs/maven-java11/charts/templates/deployment.yaml
+++ b/packs/maven-java11/charts/templates/deployment.yaml
@@ -24,10 +24,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
-{{- range $pkey, $pval := .Values.env }}
-        - name: {{ $pkey }}
-          value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 8 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/packs/maven-java11/charts/templates/ksvc.yaml
+++ b/packs/maven-java11/charts/templates/ksvc.yaml
@@ -18,10 +18,7 @@ spec:
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             env:
-{{- range $pkey, $pval := .Values.env }}
-            - name: {{ $pkey }}
-              value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 12 }}
             livenessProbe:
               httpGet:
                 path: {{ .Values.probePath }}

--- a/packs/maven/charts/templates/deployment.yaml
+++ b/packs/maven/charts/templates/deployment.yaml
@@ -24,10 +24,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
-{{- range $pkey, $pval := .Values.env }}
-        - name: {{ $pkey }}
-          value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 8 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/packs/maven/charts/templates/ksvc.yaml
+++ b/packs/maven/charts/templates/ksvc.yaml
@@ -18,10 +18,7 @@ spec:
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             env:
-{{- range $pkey, $pval := .Values.env }}
-            - name: {{ $pkey }}
-              value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 12 }}
             livenessProbe:
               httpGet:
                 path: {{ .Values.probePath }}

--- a/packs/ml-python-gpu-service/charts/templates/deployment.yaml
+++ b/packs/ml-python-gpu-service/charts/templates/deployment.yaml
@@ -24,10 +24,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
-{{- range $pkey, $pval := .Values.env }}
-        - name: {{ $pkey }}
-          value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 8 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         resources:

--- a/packs/ml-python-gpu-service/charts/templates/ksvc.yaml
+++ b/packs/ml-python-gpu-service/charts/templates/ksvc.yaml
@@ -14,10 +14,7 @@ spec:
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             env:
-{{- range $pkey, $pval := .Values.env }}
-            - name: {{ $pkey }}
-              value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 12 }}
             livenessProbe:
               httpGet:
                 path: {{ .Values.probePath }}

--- a/packs/ml-python-gpu-training/charts/templates/deployment.yaml
+++ b/packs/ml-python-gpu-training/charts/templates/deployment.yaml
@@ -26,10 +26,7 @@ spec:
         env:
         - name: TARGET_SERVICE_NAME
           value: {{ .Chart.Name | replace "-training" "-service"}}
-{{- range $pkey, $pval := .Values.env }}
-        - name: {{ $pkey }}
-          value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 8 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         resources:

--- a/packs/ml-python-gpu-training/charts/templates/ksvc.yaml
+++ b/packs/ml-python-gpu-training/charts/templates/ksvc.yaml
@@ -14,10 +14,7 @@ spec:
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             env:
-{{- range $pkey, $pval := .Values.env }}
-            - name: {{ $pkey }}
-              value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 12 }}
             livenessProbe:
               httpGet:
                 path: {{ .Values.probePath }}

--- a/packs/ml-python-service/charts/templates/deployment.yaml
+++ b/packs/ml-python-service/charts/templates/deployment.yaml
@@ -24,10 +24,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
-{{- range $pkey, $pval := .Values.env }}
-        - name: {{ $pkey }}
-          value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 8 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         resources:

--- a/packs/ml-python-service/charts/templates/ksvc.yaml
+++ b/packs/ml-python-service/charts/templates/ksvc.yaml
@@ -14,10 +14,7 @@ spec:
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             env:
-{{- range $pkey, $pval := .Values.env }}
-            - name: {{ $pkey }}
-              value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 12 }}
             livenessProbe:
               httpGet:
                 path: {{ .Values.probePath }}

--- a/packs/ml-python-training/charts/templates/deployment.yaml
+++ b/packs/ml-python-training/charts/templates/deployment.yaml
@@ -26,10 +26,7 @@ spec:
         env:
         - name: TARGET_SERVICE_NAME
           value: {{ .Chart.Name | replace "-training" "-service"}}
-{{- range $pkey, $pval := .Values.env }}
-        - name: {{ $pkey }}
-          value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 8 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         resources:

--- a/packs/ml-python-training/charts/templates/ksvc.yaml
+++ b/packs/ml-python-training/charts/templates/ksvc.yaml
@@ -14,10 +14,7 @@ spec:
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             env:
-{{- range $pkey, $pval := .Values.env }}
-            - name: {{ $pkey }}
-              value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 12 }}
             livenessProbe:
               httpGet:
                 path: {{ .Values.probePath }}

--- a/packs/php/charts/templates/deployment.yaml
+++ b/packs/php/charts/templates/deployment.yaml
@@ -24,10 +24,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
-{{- range $pkey, $pval := .Values.env }}
-        - name: {{ $pkey }}
-          value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 8 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/packs/php/charts/templates/ksvc.yaml
+++ b/packs/php/charts/templates/ksvc.yaml
@@ -18,10 +18,7 @@ spec:
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             env:
-{{- range $pkey, $pval := .Values.env }}
-            - name: {{ $pkey }}
-              value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 12 }}
             livenessProbe:
               httpGet:
                 path: {{ .Values.probePath }}

--- a/packs/python/charts/templates/deployment.yaml
+++ b/packs/python/charts/templates/deployment.yaml
@@ -24,10 +24,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
-{{- range $pkey, $pval := .Values.env }}
-        - name: {{ $pkey }}
-          value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 8 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         resources:

--- a/packs/python/charts/templates/ksvc.yaml
+++ b/packs/python/charts/templates/ksvc.yaml
@@ -18,10 +18,7 @@ spec:
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             env:
-{{- range $pkey, $pval := .Values.env }}
-            - name: {{ $pkey }}
-              value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 12 }}
             livenessProbe:
               httpGet:
                 path: {{ .Values.probePath }}

--- a/packs/ruby/charts/templates/deployment.yaml
+++ b/packs/ruby/charts/templates/deployment.yaml
@@ -24,10 +24,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
-{{- range $pkey, $pval := .Values.env }}
-        - name: {{ $pkey }}
-          value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 8 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/packs/ruby/charts/templates/ksvc.yaml
+++ b/packs/ruby/charts/templates/ksvc.yaml
@@ -18,10 +18,7 @@ spec:
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             env:
-{{- range $pkey, $pval := .Values.env }}
-            - name: {{ $pkey }}
-              value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 12 }}
             livenessProbe:
               httpGet:
                 path: {{ .Values.probePath }}

--- a/packs/rust/charts/templates/deployment.yaml
+++ b/packs/rust/charts/templates/deployment.yaml
@@ -24,10 +24,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
-{{- range $pkey, $pval := .Values.env }}
-        - name: {{ $pkey }}
-          value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 8 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/packs/rust/charts/templates/ksvc.yaml
+++ b/packs/rust/charts/templates/ksvc.yaml
@@ -18,10 +18,7 @@ spec:
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             env:
-{{- range $pkey, $pval := .Values.env }}
-            - name: {{ $pkey }}
-              value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 12 }}
             livenessProbe:
               httpGet:
                 path: {{ .Values.probePath }}

--- a/packs/scala/charts/templates/deployment.yaml
+++ b/packs/scala/charts/templates/deployment.yaml
@@ -24,10 +24,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
-{{- range $pkey, $pval := .Values.env }}
-        - name: {{ $pkey }}
-          value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 8 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/packs/scala/charts/templates/ksvc.yaml
+++ b/packs/scala/charts/templates/ksvc.yaml
@@ -18,10 +18,7 @@ spec:
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             env:
-{{- range $pkey, $pval := .Values.env }}
-            - name: {{ $pkey }}
-              value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 12 }}
             livenessProbe:
               httpGet:
                 path: {{ .Values.probePath }}

--- a/packs/swift/chart/templates/deployment.yaml
+++ b/packs/swift/chart/templates/deployment.yaml
@@ -24,10 +24,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
-{{- range $pkey, $pval := .Values.env }}
-        - name: {{ $pkey }}
-          value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 8 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         resources:

--- a/packs/swift/chart/templates/ksvc.yaml
+++ b/packs/swift/chart/templates/ksvc.yaml
@@ -18,10 +18,7 @@ spec:
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             env:
-{{- range $pkey, $pval := .Values.env }}
-            - name: {{ $pkey }}
-              value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 12 }}
             livenessProbe:
               httpGet:
                 path: {{ .Values.probePath }}

--- a/packs/typescript/charts/templates/deployment.yaml
+++ b/packs/typescript/charts/templates/deployment.yaml
@@ -24,10 +24,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
-{{- range $pkey, $pval := .Values.env }}
-        - name: {{ $pkey }}
-          value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 8 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/packs/typescript/charts/templates/ksvc.yaml
+++ b/packs/typescript/charts/templates/ksvc.yaml
@@ -18,10 +18,7 @@ spec:
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             env:
-{{- range $pkey, $pval := .Values.env }}
-            - name: {{ $pkey }}
-              value: {{ quote $pval }}
-{{- end }}
+{{ toYaml .Values.env | indent 12 }}
             livenessProbe:
               httpGet:
                 path: {{ .Values.probePath }}


### PR DESCRIPTION
As noted in issue #99, instead of a simple env indent (the same way we do with envFrom) we use this fancy key:value, which doesn't seem to add anything, but instead create frustration as we can't use valueFrom to retrieve values from a configmap or a secret, to factorize database values for example.

This PR replace the key:value declaration by a simple toYaml statement.

Fixes #99